### PR TITLE
Expose sqlx runtime choice as a feature in the SQL catalog

### DIFF
--- a/iceberg-sql-catalog/Cargo.toml
+++ b/iceberg-sql-catalog/Cargo.toml
@@ -9,6 +9,10 @@ license = "Apache-2.0"
 
 repository = "https://github.com/JanKaul/iceberg-rust"
 
+[features]
+runtime-tokio = ["sqlx/runtime-tokio"]
+runtime-async-std = ["sqlx/runtime-async-std"]
+
 [dependencies]
 async-trait.workspace = true
 futures.workspace = true

--- a/iceberg-sql-catalog/Cargo.toml
+++ b/iceberg-sql-catalog/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 repository = "https://github.com/JanKaul/iceberg-rust"
 
 [features]
+default = ["runtime-tokio"]
 runtime-tokio = ["sqlx/runtime-tokio"]
 runtime-async-std = ["sqlx/runtime-async-std"]
 


### PR DESCRIPTION
Not sure whether you are interested in contributions, but I was testing the crate and ran into the following panic when running the README: https://github.com/launchbadge/sqlx/blob/293c55ce896edefc797b6b819c8b27cd327382bb/sqlx-core/src/rt/mod.rs#L143

This PR makes tokio the default runtime, while keeping the possibility to  use `async-std`. But TBH, I doubt many potential users would want to use `async-std` anyway.