### PR TITLE
Avoid negative snaphot ids

### DIFF
--- a/iceberg-rust-spec/src/spec/snapshot.rs
+++ b/iceberg-rust-spec/src/spec/snapshot.rs
@@ -79,7 +79,7 @@ impl Snapshot {
 pub fn generate_snapshot_id() -> i64 {
     let mut bytes: [u8; 8] = [0u8; 8];
     getrandom::getrandom(&mut bytes).unwrap();
-    u64::from_le_bytes(bytes) as i64
+    i64::from_le_bytes(bytes).abs()
 }
 
 impl fmt::Display for Snapshot {


### PR DESCRIPTION
As the snapshot id is part of the manifest list name, having a negative value gives weird file names:

```
snap--199151010591443303127a4577f-b6fa-49ff-bee4-8d96ad643ac6.avro
```

I assume interpreting the random bytes as u64 was intended to ensure that the value is positive, but the cast to i64 can overflow so some values end up being negative.