### PR TITLE
Improve append

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,6 +2452,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "smallvec",
  "sqlparser",
  "thiserror",
  "thrift",
@@ -4294,9 +4295,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
  "serde",
 ]

--- a/datafusion_iceberg/src/table.rs
+++ b/datafusion_iceberg/src/table.rs
@@ -929,7 +929,17 @@ mod tests {
                 (12, 2, 3, '2020-01-04', 1),
                 (13, 1, 1, '2020-01-05', 4),
                 (14, 3, 2, '2020-01-05', 2),
-                (15, 2, 3, '2020-01-05', 3);",
+                (15, 2, 3, '2020-01-05', 3),
+                (16, 2, 3, '2020-01-05', 3),
+                (17, 1, 3, '2020-01-06', 1),
+                (18, 2, 1, '2020-01-06', 2),
+                (19, 2, 2, '2020-01-06', 1),
+                (20, 1, 2, '2020-01-07', 3),
+                (21, 3, 1, '2020-01-07', 2),
+                (22, 2, 3, '2020-01-07', 1),
+                (23, 1, 1, '2020-01-08', 4),
+                (24, 3, 2, '2020-01-08', 2),
+                (25, 2, 3, '2020-01-08', 3);",
         )
         .await
         .expect("Failed to create query plan for insert")
@@ -961,9 +971,9 @@ mod tests {
                 );
                 for (product_id, amount) in product_ids.iter().zip(amounts) {
                     match product_id.unwrap() {
-                        1 => assert_eq!(amount.unwrap(), 7),
-                        2 => assert_eq!(amount.unwrap(), 4),
-                        3 => assert_eq!(amount.unwrap(), 1),
+                        1 => assert_eq!(amount.unwrap(), 11),
+                        2 => assert_eq!(amount.unwrap(), 7),
+                        3 => assert_eq!(amount.unwrap(), 2),
                         _ => panic!("Unexpected order id"),
                     }
                 }

--- a/datafusion_iceberg/src/table.rs
+++ b/datafusion_iceberg/src/table.rs
@@ -920,7 +920,13 @@ mod tests {
             "INSERT INTO orders (id, customer_id, product_id, date, amount) VALUES 
                 (7, 1, 3, '2020-01-03', 1),
                 (8, 2, 1, '2020-01-03', 2),
-                (9, 2, 2, '2020-01-03', 1);",
+                (9, 2, 2, '2020-01-03', 1),
+                (10, 1, 2, '2020-01-04', 3),
+                (11, 3, 1, '2020-01-04', 2),
+                (12, 2, 3, '2020-01-04', 1),
+                (13, 1, 1, '2020-01-05', 4),
+                (14, 3, 2, '2020-01-05', 2),
+                (15, 2, 3, '2020-01-05', 3);",
         )
         .await
         .expect("Failed to create query plan for insert")
@@ -952,8 +958,9 @@ mod tests {
                 );
                 for (product_id, amount) in product_ids.iter().zip(amounts) {
                     match product_id.unwrap() {
-                        1 => assert_eq!(amount.unwrap(), 3),
-                        2 | 3 => assert_eq!(amount.unwrap(), 1),
+                        1 => assert_eq!(amount.unwrap(), 7),
+                        2 => assert_eq!(amount.unwrap(), 4),
+                        3 => assert_eq!(amount.unwrap(), 1),
                         _ => panic!("Unexpected order id"),
                     }
                 }

--- a/datafusion_iceberg/src/table.rs
+++ b/datafusion_iceberg/src/table.rs
@@ -980,11 +980,8 @@ mod tests {
             }
         }
 
-        match table.tabular.read().await.deref() {
-            Tabular::Table(table) => {
-                assert_eq!(table.manifests(None, None).await.unwrap().len(), 2);
-            }
-            _ => (),
+        if let Tabular::Table(table) = table.tabular.read().await.deref() {
+            assert_eq!(table.manifests(None, None).await.unwrap().len(), 2);
         };
     }
 

--- a/iceberg-file-catalog/src/lib.rs
+++ b/iceberg-file-catalog/src/lib.rs
@@ -113,7 +113,7 @@ impl Catalog for FileCatalog {
             .map_err(IcebergError::from)
             .map_ok(|x| {
                 let path = x.location.as_ref();
-                self.identifier(&path)
+                self.identifier(path)
             })
             .try_collect()
             .await
@@ -501,7 +501,7 @@ impl Catalog for FileCatalog {
 
 impl FileCatalog {
     fn namespace_path(&self, namespace: &str) -> String {
-        self.path.as_str().trim_end_matches('/').to_owned() + "/" + &self.name + "/" + &namespace
+        self.path.as_str().trim_end_matches('/').to_owned() + "/" + &self.name + "/" + namespace
     }
 
     fn tabular_path(&self, namespace: &str, name: &str) -> String {
@@ -509,7 +509,7 @@ impl FileCatalog {
             + "/"
             + &self.name
             + "/"
-            + &namespace
+            + namespace
             + "/"
             + name
     }
@@ -523,7 +523,7 @@ impl FileCatalog {
             .try_filter(|x| {
                 future::ready(
                     x.ends_with("metadata.json")
-                        && x.starts_with(&(path.clone() + "/v").trim_start_matches('/')),
+                        && x.starts_with((path.clone() + "/v").trim_start_matches('/')),
                 )
             })
             .try_collect()
@@ -551,9 +551,7 @@ impl FileCatalog {
         let parts = path
             .trim_start_matches(self.path.trim_start_matches('/'))
             .trim_start_matches('/')
-            .split('/')
-            .skip(1)
-            .next()
+            .split('/').nth(1)
             .ok_or(IcebergError::InvalidFormat("Namespace in path".to_owned()))?
             .to_owned();
         Namespace::try_new(&[parts]).map_err(IcebergError::from)

--- a/iceberg-rust-spec/src/spec/manifest.rs
+++ b/iceberg-rust-spec/src/spec/manifest.rs
@@ -189,8 +189,10 @@ pub struct ManifestEntry {
     status: Status,
     /// Snapshot id where the file was added, or deleted if status is 2.
     /// Inherited when null.
+    #[builder(setter(strip_option), default)]
     snapshot_id: Option<i64>,
     /// Sequence number when the file was added. Inherited when null.
+    #[builder(setter(strip_option), default)]
     sequence_number: Option<i64>,
     /// File path, partition tuple, metrics, …
     data_file: DataFile,

--- a/iceberg-rust-spec/src/spec/manifest_list.rs
+++ b/iceberg-rust-spec/src/spec/manifest_list.rs
@@ -49,7 +49,7 @@ impl<'a, 'metadata, R: Read> ManifestListReader<'a, 'metadata, R> {
             FormatVersion::V2 => manifest_list_schema_v2(),
         };
         Ok(Self {
-            reader: AvroReader::with_schema(&schema, reader)?
+            reader: AvroReader::with_schema(schema, reader)?
                 .zip(repeat(table_metadata))
                 .map(avro_value_to_manifest_file),
         })
@@ -781,7 +781,7 @@ mod tests {
 
         let schema = manifest_list_schema_v2();
 
-        let mut writer = apache_avro::Writer::new(&schema, Vec::new());
+        let mut writer = apache_avro::Writer::new(schema, Vec::new());
 
         writer.append_ser(manifest_file.clone()).unwrap();
 
@@ -861,7 +861,7 @@ mod tests {
 
         let schema = manifest_list_schema_v1();
 
-        let mut writer = apache_avro::Writer::new(&schema, Vec::new());
+        let mut writer = apache_avro::Writer::new(schema, Vec::new());
 
         writer.append_ser(manifest_file.clone()).unwrap();
 

--- a/iceberg-rust-spec/src/spec/manifest_list.rs
+++ b/iceberg-rust-spec/src/spec/manifest_list.rs
@@ -773,8 +773,8 @@ mod tests {
             partitions: Some(vec![FieldSummary {
                 contains_null: true,
                 contains_nan: Some(false),
-                lower_bound: Some(Value::Date(1234)),
-                upper_bound: Some(Value::Date(76890)),
+                lower_bound: Some(Value::Int(1234)),
+                upper_bound: Some(Value::Int(76890)),
             }]),
             key_metadata: None,
         };
@@ -853,8 +853,8 @@ mod tests {
             partitions: Some(vec![FieldSummary {
                 contains_null: true,
                 contains_nan: Some(false),
-                lower_bound: Some(Value::Date(1234)),
-                upper_bound: Some(Value::Date(76890)),
+                lower_bound: Some(Value::Int(1234)),
+                upper_bound: Some(Value::Int(76890)),
             }]),
             key_metadata: None,
         };

--- a/iceberg-rust-spec/src/spec/partition.rs
+++ b/iceberg-rust-spec/src/spec/partition.rs
@@ -183,10 +183,13 @@ impl PartitionSpec {
             .map(|field| {
                 schema
                     .get(field.source_id as usize)
-                    .map(|x| x.field_type.clone())
+                    .ok_or(Error::NotFound(
+                        "Partition field".to_owned(),
+                        field.name.clone(),
+                    ))
+                    .and_then(|x| x.field_type.clone().tranform(&field.transform))
             })
-            .collect::<Option<Vec<_>>>()
-            .ok_or(Error::InvalidFormat("partition spec".to_string()))
+            .collect::<Result<Vec<_>, Error>>()
     }
 }
 

--- a/iceberg-rust-spec/src/spec/table_metadata.rs
+++ b/iceberg-rust-spec/src/spec/table_metadata.rs
@@ -733,7 +733,7 @@ pub struct SnapshotLog {
     pub timestamp_ms: i64,
 }
 
-#[derive(Debug, Serialize_repr, Deserialize_repr, PartialEq, Eq, Clone)]
+#[derive(Debug, Serialize_repr, Deserialize_repr, PartialEq, Eq, Clone, Copy)]
 #[repr(u8)]
 /// Iceberg format version
 #[derive(Default)]

--- a/iceberg-rust-spec/src/spec/values.rs
+++ b/iceberg-rust-spec/src/spec/values.rs
@@ -280,7 +280,7 @@ impl Hash for Struct {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         for key in self.keys().sorted() {
             key.hash(state);
-            self.get(&key).hash(state);
+            self.get(key).hash(state);
         }
     }
 }
@@ -883,7 +883,7 @@ impl TrySub for Value {
                 Ok(Value::TimestampTZ(own - other))
             }
             (Value::String(own), Value::String(other)) => {
-                Ok(Value::LongInt(sub_string(&own, &other) as i64))
+                Ok(Value::LongInt(sub_string(own, other) as i64))
             }
             (x, y) => Err(Error::Type(
                 x.datatype().to_string(),

--- a/iceberg-rust-spec/src/spec/values.rs
+++ b/iceberg-rust-spec/src/spec/values.rs
@@ -829,43 +829,13 @@ mod datetime {
     }
 }
 
-pub trait TryAdd: Sized {
-    fn try_add(&self, other: &Self) -> Result<Self, Error>;
-}
 pub trait TrySub: Sized {
     fn try_sub(&self, other: &Self) -> Result<Self, Error>;
-}
-
-impl<T: Add<Output = T> + Copy> TryAdd for T {
-    fn try_add(&self, other: &Self) -> Result<Self, Error> {
-        Ok(*self + *other)
-    }
 }
 
 impl<T: Sub<Output = T> + Copy> TrySub for T {
     fn try_sub(&self, other: &Self) -> Result<Self, Error> {
         Ok(*self - *other)
-    }
-}
-
-impl TryAdd for Value {
-    fn try_add(&self, other: &Self) -> Result<Self, Error> {
-        match (self, other) {
-            (Value::Int(own), Value::Int(other)) => Ok(Value::Int(own + other)),
-            (Value::LongInt(own), Value::LongInt(other)) => Ok(Value::LongInt(own + other)),
-            (Value::Float(own), Value::Float(other)) => Ok(Value::Float(*own + *other)),
-            (Value::Double(own), Value::Double(other)) => Ok(Value::Double(*own + *other)),
-            (Value::Date(own), Value::Date(other)) => Ok(Value::Date(own + other)),
-            (Value::Time(own), Value::Time(other)) => Ok(Value::Time(own + other)),
-            (Value::Timestamp(own), Value::Timestamp(other)) => Ok(Value::Timestamp(own + other)),
-            (Value::TimestampTZ(own), Value::TimestampTZ(other)) => {
-                Ok(Value::TimestampTZ(own + other))
-            }
-            (x, y) => Err(Error::Type(
-                x.datatype().to_string(),
-                y.datatype().to_string(),
-            )),
-        }
     }
 }
 

--- a/iceberg-rust-spec/src/spec/values.rs
+++ b/iceberg-rust-spec/src/spec/values.rs
@@ -817,6 +817,55 @@ mod datetime {
     }
 }
 
+pub trait TryAdd: Sized {
+    fn try_add(&self, other: &Self) -> Result<Self, Error>;
+}
+pub trait TrySub: Sized {
+    fn try_sub(&self, other: &Self) -> Result<Self, Error>;
+}
+
+impl TryAdd for Value {
+    fn try_add(&self, other: &Self) -> Result<Self, Error> {
+        match (self, other) {
+            (Value::Int(own), Value::Int(other)) => Ok(Value::Int(own + other)),
+            (Value::LongInt(own), Value::LongInt(other)) => Ok(Value::LongInt(own + other)),
+            (Value::Float(own), Value::Float(other)) => Ok(Value::Float(*own + *other)),
+            (Value::Double(own), Value::Double(other)) => Ok(Value::Double(*own + *other)),
+            (Value::Date(own), Value::Date(other)) => Ok(Value::Date(own + other)),
+            (Value::Time(own), Value::Time(other)) => Ok(Value::Time(own + other)),
+            (Value::Timestamp(own), Value::Timestamp(other)) => Ok(Value::Timestamp(own + other)),
+            (Value::TimestampTZ(own), Value::TimestampTZ(other)) => {
+                Ok(Value::TimestampTZ(own + other))
+            }
+            (x, y) => Err(Error::Type(
+                x.datatype().to_string(),
+                y.datatype().to_string(),
+            )),
+        }
+    }
+}
+
+impl TrySub for Value {
+    fn try_sub(&self, other: &Self) -> Result<Self, Error> {
+        match (self, other) {
+            (Value::Int(own), Value::Int(other)) => Ok(Value::Int(own - other)),
+            (Value::LongInt(own), Value::LongInt(other)) => Ok(Value::LongInt(own - other)),
+            (Value::Float(own), Value::Float(other)) => Ok(Value::Float(*own - *other)),
+            (Value::Double(own), Value::Double(other)) => Ok(Value::Double(*own - *other)),
+            (Value::Date(own), Value::Date(other)) => Ok(Value::Date(own - other)),
+            (Value::Time(own), Value::Time(other)) => Ok(Value::Time(own - other)),
+            (Value::Timestamp(own), Value::Timestamp(other)) => Ok(Value::Timestamp(own - other)),
+            (Value::TimestampTZ(own), Value::TimestampTZ(other)) => {
+                Ok(Value::TimestampTZ(own - other))
+            }
+            (x, y) => Err(Error::Type(
+                x.datatype().to_string(),
+                y.datatype().to_string(),
+            )),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/iceberg-rust-spec/src/spec/values.rs
+++ b/iceberg-rust-spec/src/spec/values.rs
@@ -8,6 +8,7 @@ use std::{
     fmt,
     hash::Hash,
     io::Cursor,
+    ops::{Add, Sub},
     slice::Iter,
 };
 
@@ -833,6 +834,18 @@ pub trait TryAdd: Sized {
 }
 pub trait TrySub: Sized {
     fn try_sub(&self, other: &Self) -> Result<Self, Error>;
+}
+
+impl<T: Add<Output = T> + Copy> TryAdd for T {
+    fn try_add(&self, other: &Self) -> Result<Self, Error> {
+        Ok(*self + *other)
+    }
+}
+
+impl<T: Sub<Output = T> + Copy> TrySub for T {
+    fn try_sub(&self, other: &Self) -> Result<Self, Error> {
+        Ok(*self - *other)
+    }
 }
 
 impl TryAdd for Value {

--- a/iceberg-rust/Cargo.toml
+++ b/iceberg-rust/Cargo.toml
@@ -30,4 +30,5 @@ thrift = { version = "0.17.0", default-features = false }
 thiserror = { workspace = true }
 derive-getters = { workspace = true }
 iceberg-rust-spec = { path = "../iceberg-rust-spec", version = "0.5.8" }
+smallvec = { version = "1.13.2", features = ["const_generics"] }
 

--- a/iceberg-rust/src/lib.rs
+++ b/iceberg-rust/src/lib.rs
@@ -10,4 +10,5 @@ pub mod materialized_view;
 pub mod spec;
 pub mod sql;
 pub mod table;
+pub(crate) mod util;
 pub mod view;

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -1,0 +1,331 @@
+/*!
+ * Helpers to deal with manifest files
+*/
+
+use std::sync::Arc;
+
+use apache_avro::{Schema as AvroSchema, Writer as AvroWriter};
+use iceberg_rust_spec::{
+    manifest::ManifestEntry,
+    manifest_list::{self, FieldSummary, ManifestListEntry},
+    partition::PartitionField,
+    schema::{SchemaV1, SchemaV2},
+    table_metadata::{FormatVersion, TableMetadata},
+    util::strip_prefix,
+    values::{Struct, Value},
+};
+use object_store::ObjectStore;
+
+use crate::error::Error;
+
+/// A helper to write entries into a manifest
+pub struct ManifestWriter<'schema, 'metadata> {
+    table_metadata: &'metadata TableMetadata,
+    manifest: ManifestListEntry,
+    writer: AvroWriter<'schema, Vec<u8>>,
+}
+
+impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
+    /// Create empty manifest writer
+    pub fn new(
+        manifest_location: &str,
+        snapshot_id: i64,
+        schema: &'schema AvroSchema,
+        table_metadata: &'metadata TableMetadata,
+        branch: Option<&str>,
+    ) -> Result<Self, Error> {
+        let mut writer = AvroWriter::new(schema, Vec::new());
+
+        writer.add_user_metadata(
+            "format-version".to_string(),
+            match table_metadata.format_version {
+                FormatVersion::V1 => "1".as_bytes(),
+                FormatVersion::V2 => "2".as_bytes(),
+            },
+        )?;
+
+        writer.add_user_metadata(
+            "schema".to_string(),
+            match table_metadata.format_version {
+                FormatVersion::V1 => serde_json::to_string(&Into::<SchemaV1>::into(
+                    table_metadata.current_schema(branch)?.clone(),
+                ))?,
+                FormatVersion::V2 => serde_json::to_string(&Into::<SchemaV2>::into(
+                    table_metadata.current_schema(branch)?.clone(),
+                ))?,
+            },
+        )?;
+
+        writer.add_user_metadata(
+            "schema-id".to_string(),
+            serde_json::to_string(&table_metadata.current_schema(branch)?.schema_id())?,
+        )?;
+
+        writer.add_user_metadata(
+            "partition-spec".to_string(),
+            serde_json::to_string(&table_metadata.default_partition_spec()?.fields())?,
+        )?;
+
+        writer.add_user_metadata(
+            "partition-spec-id".to_string(),
+            serde_json::to_string(&table_metadata.default_partition_spec()?.spec_id())?,
+        )?;
+
+        writer.add_user_metadata("content".to_string(), "data")?;
+
+        let manifest = ManifestListEntry {
+            format_version: table_metadata.format_version,
+            manifest_path: manifest_location.to_owned(),
+            manifest_length: 0,
+            partition_spec_id: table_metadata.default_spec_id,
+            content: manifest_list::Content::Data,
+            sequence_number: table_metadata.last_sequence_number,
+            min_sequence_number: 0,
+            added_snapshot_id: snapshot_id,
+            added_files_count: Some(0),
+            existing_files_count: Some(0),
+            deleted_files_count: Some(0),
+            added_rows_count: Some(0),
+            existing_rows_count: Some(0),
+            deleted_rows_count: Some(0),
+            partitions: None,
+            key_metadata: None,
+        };
+
+        Ok(ManifestWriter {
+            manifest,
+            writer,
+            table_metadata,
+        })
+    }
+
+    /// Create an manifest writer from an existing manifest
+    pub fn from_existing(
+        bytes: &[u8],
+        manifest: ManifestListEntry,
+        schema: &'schema AvroSchema,
+        table_metadata: &'metadata TableMetadata,
+        branch: Option<&str>,
+    ) -> Result<Self, Error> {
+        let manifest_reader = apache_avro::Reader::new(bytes)?;
+
+        let mut writer = AvroWriter::new(schema, Vec::new());
+
+        writer.add_user_metadata(
+            "format-version".to_string(),
+            match table_metadata.format_version {
+                FormatVersion::V1 => "1".as_bytes(),
+                FormatVersion::V2 => "2".as_bytes(),
+            },
+        )?;
+
+        writer.add_user_metadata(
+            "schema".to_string(),
+            match table_metadata.format_version {
+                FormatVersion::V1 => serde_json::to_string(&Into::<SchemaV1>::into(
+                    table_metadata.current_schema(branch)?.clone(),
+                ))?,
+                FormatVersion::V2 => serde_json::to_string(&Into::<SchemaV2>::into(
+                    table_metadata.current_schema(branch)?.clone(),
+                ))?,
+            },
+        )?;
+
+        writer.add_user_metadata(
+            "schema-id".to_string(),
+            serde_json::to_string(&table_metadata.current_schema(branch)?.schema_id())?,
+        )?;
+
+        writer.add_user_metadata(
+            "partition-spec".to_string(),
+            serde_json::to_string(&table_metadata.default_partition_spec()?.fields())?,
+        )?;
+
+        writer.add_user_metadata(
+            "partition-spec-id".to_string(),
+            serde_json::to_string(&table_metadata.default_partition_spec()?.spec_id())?,
+        )?;
+
+        writer.add_user_metadata("content".to_string(), "data")?;
+
+        writer.extend(manifest_reader.filter_map(Result::ok))?;
+
+        Ok(ManifestWriter {
+            manifest,
+            writer,
+            table_metadata,
+        })
+    }
+
+    /// Add an manifest entry to the manifest
+    pub fn append(&mut self, manifest_entry: ManifestEntry) -> Result<(), Error> {
+        let mut added_rows_count = 0;
+
+        if self.manifest.partitions.is_none() {
+            self.manifest.partitions = Some(
+                self.table_metadata
+                    .default_partition_spec()?
+                    .fields()
+                    .iter()
+                    .map(|_| FieldSummary {
+                        contains_null: false,
+                        contains_nan: None,
+                        lower_bound: None,
+                        upper_bound: None,
+                    })
+                    .collect::<Vec<FieldSummary>>(),
+            );
+        }
+
+        added_rows_count += manifest_entry.data_file().record_count();
+        update_partitions(
+            self.manifest.partitions.as_mut().unwrap(),
+            manifest_entry.data_file().partition(),
+            self.table_metadata.default_partition_spec()?.fields(),
+        )?;
+
+        self.writer.append_ser(manifest_entry)?;
+
+        self.manifest.added_files_count = match self.manifest.added_files_count {
+            Some(count) => Some(count + 1),
+            None => Some(1),
+        };
+        self.manifest.added_rows_count = match self.manifest.added_rows_count {
+            Some(count) => Some(count + added_rows_count),
+            None => Some(added_rows_count),
+        };
+
+        Ok(())
+    }
+
+    /// Write the manifest to object storage and return the manifest-list-entry
+    pub async fn write(
+        mut self,
+        object_store: Arc<dyn ObjectStore>,
+    ) -> Result<ManifestListEntry, Error> {
+        let manifest_bytes = self.writer.into_inner()?;
+
+        let manifest_length: i64 = manifest_bytes.len() as i64;
+
+        self.manifest.manifest_length += manifest_length;
+
+        object_store
+            .put(
+                &strip_prefix(&self.manifest.manifest_path).as_str().into(),
+                manifest_bytes.into(),
+            )
+            .await?;
+        Ok(self.manifest)
+    }
+}
+
+fn update_partitions(
+    partitions: &mut [FieldSummary],
+    partition_values: &Struct,
+    partition_columns: &[PartitionField],
+) -> Result<(), Error> {
+    for (field, summary) in partition_columns.iter().zip(partitions.iter_mut()) {
+        let value = partition_values.get(field.name()).and_then(|x| x.as_ref());
+        if let Some(value) = value {
+            if summary.lower_bound.is_none() {
+                summary.lower_bound = Some(value.clone());
+            } else if let Some(lower_bound) = &mut summary.lower_bound {
+                match (value, lower_bound) {
+                    (Value::Int(val), Value::Int(current)) => {
+                        if *current > *val {
+                            *current = *val
+                        }
+                    }
+                    (Value::LongInt(val), Value::LongInt(current)) => {
+                        if *current > *val {
+                            *current = *val
+                        }
+                    }
+                    (Value::Float(val), Value::Float(current)) => {
+                        if *current > *val {
+                            *current = *val
+                        }
+                    }
+                    (Value::Double(val), Value::Double(current)) => {
+                        if *current > *val {
+                            *current = *val
+                        }
+                    }
+                    (Value::Date(val), Value::Date(current)) => {
+                        if *current > *val {
+                            *current = *val
+                        }
+                    }
+                    (Value::Time(val), Value::Time(current)) => {
+                        if *current > *val {
+                            *current = *val
+                        }
+                    }
+                    (Value::Timestamp(val), Value::Timestamp(current)) => {
+                        if *current > *val {
+                            *current = *val
+                        }
+                    }
+                    (Value::TimestampTZ(val), Value::TimestampTZ(current)) => {
+                        if *current > *val {
+                            *current = *val
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if summary.upper_bound.is_none() {
+                summary.upper_bound = Some(value.clone());
+            } else if let Some(upper_bound) = &mut summary.upper_bound {
+                match (value, upper_bound) {
+                    (Value::Int(val), Value::Int(current)) => {
+                        if *current < *val {
+                            *current = *val
+                        }
+                    }
+                    (Value::LongInt(val), Value::LongInt(current)) => {
+                        if *current < *val {
+                            *current = *val
+                        }
+                    }
+                    (Value::Float(val), Value::Float(current)) => {
+                        if *current < *val {
+                            *current = *val
+                        }
+                    }
+                    (Value::Double(val), Value::Double(current)) => {
+                        if *current < *val {
+                            *current = *val
+                        }
+                    }
+                    (Value::Date(val), Value::Date(current)) => {
+                        if *current < *val {
+                            *current = *val
+                        }
+                    }
+                    (Value::Time(val), Value::Time(current)) => {
+                        if *current < *val {
+                            *current = *val
+                        }
+                    }
+                    (Value::Timestamp(val), Value::Timestamp(current)) => {
+                        if *current < *val {
+                            *current = *val
+                        }
+                    }
+                    (Value::TimestampTZ(val), Value::TimestampTZ(current)) => {
+                        if *current < *val {
+                            *current = *val
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// TODO
+#[cfg(test)]
+mod tests {}

--- a/iceberg-rust/src/table/mod.rs
+++ b/iceberg-rust/src/table/mod.rs
@@ -29,6 +29,7 @@ use crate::{
     table::transaction::TableTransaction,
 };
 
+pub mod manifest;
 pub mod transaction;
 
 #[derive(Debug)]

--- a/iceberg-rust/src/table/mod.rs
+++ b/iceberg-rust/src/table/mod.rs
@@ -4,6 +4,7 @@ Defining the [Table] struct that represents an iceberg table.
 
 use std::{io::Cursor, iter::repeat, sync::Arc};
 
+use manifest::ManifestReader;
 use object_store::{path::Path, ObjectStore};
 
 use futures::{
@@ -12,7 +13,7 @@ use futures::{
 use iceberg_rust_spec::util::{self};
 use iceberg_rust_spec::{
     spec::{
-        manifest::{Content, ManifestEntry, ManifestReader},
+        manifest::{Content, ManifestEntry},
         manifest_list::ManifestListEntry,
         schema::Schema,
         table_metadata::TableMetadata,

--- a/iceberg-rust/src/table/transaction/append.rs
+++ b/iceberg-rust/src/table/transaction/append.rs
@@ -10,7 +10,7 @@ use crate::{
 
 /// Split sets of datafiles depending on their partition_values
 #[allow(clippy::type_complexity)]
-pub(crate) fn split_datafiles_once(
+pub fn split_datafiles_once(
     files: impl Iterator<Item = Result<ManifestEntry, Error>>,
     rect: Rectangle,
     names: &[&str],

--- a/iceberg-rust/src/table/transaction/append.rs
+++ b/iceberg-rust/src/table/transaction/append.rs
@@ -10,7 +10,7 @@ use crate::{
 
 /// Split sets of datafiles depending on their partition_values
 #[allow(clippy::type_complexity)]
-pub fn split_datafiles_once(
+fn split_datafiles_once(
     files: impl Iterator<Item = Result<ManifestEntry, Error>>,
     rect: Rectangle,
     names: &[&str],

--- a/iceberg-rust/src/table/transaction/append.rs
+++ b/iceberg-rust/src/table/transaction/append.rs
@@ -1,10 +1,14 @@
 use std::cmp::Ordering;
 
-use iceberg_rust_spec::manifest::ManifestEntry;
+use iceberg_rust_spec::{
+    manifest::ManifestEntry,
+    manifest_list::{ManifestListEntry, ManifestListReader},
+};
+use smallvec::SmallVec;
 
 use crate::{
     error::Error,
-    util::{cmp_with_priority, partition_struct_to_vec, try_sub, Rectangle},
+    util::{cmp_with_priority, partition_struct_to_vec, summary_to_rectangle, try_sub, Rectangle},
 };
 
 /// Split sets of datafiles depending on their partition_values
@@ -83,4 +87,77 @@ pub(crate) fn split_datafiles(
         smaller.append(&mut larger);
         Ok(smaller)
     }
+}
+
+/// Select the manifest that yields the smallest bounding rectangle after the bounding rectangle of the new values has been added.
+pub(crate) fn select_manifest(
+    partition_column_names: &SmallVec<[&str; 4]>,
+    mut manifest_list_reader: ManifestListReader<&[u8]>,
+    file_count: &mut usize,
+    manifest_list_writer: &mut apache_avro::Writer<Vec<u8>>,
+    bounding_partition_values: &Rectangle,
+) -> Result<ManifestListEntry, Error> {
+    let manifest =
+        if partition_column_names.is_empty() {
+            // Find the manifest with the lowest row count
+            manifest_list_reader
+                .try_fold(None, |acc, x| {
+                    let manifest = x?;
+
+                    let row_count = manifest.added_rows_count;
+
+                    *file_count += manifest.added_files_count.unwrap_or(0) as usize;
+
+                    let Some((old_row_count, old_manifest)) = acc else {
+                        return Ok::<_, Error>(Some((row_count, manifest)));
+                    };
+
+                    let Some(row_count) = row_count else {
+                        return Ok(Some((old_row_count, old_manifest)));
+                    };
+
+                    if old_row_count.is_none() || old_row_count.is_some_and(|x| x > row_count) {
+                        manifest_list_writer.append_ser(old_manifest)?;
+                        Ok(Some((Some(row_count), manifest)))
+                    } else {
+                        manifest_list_writer.append_ser(manifest)?;
+                        Ok(Some((old_row_count, old_manifest)))
+                    }
+                })?
+                .ok_or(Error::NotFound("Manifest".to_owned(), "file".to_owned()))?
+                .1
+        } else {
+            // Find the manifest with the smallest bounding partition values
+            manifest_list_reader
+                .try_fold(None, |acc, x| {
+                    let manifest = x?;
+
+                    let mut bounds =
+                        summary_to_rectangle(manifest.partitions.as_ref().ok_or(
+                            Error::NotFound("Partition".to_owned(), "struct".to_owned()),
+                        )?)?;
+
+                    bounds.expand(bounding_partition_values);
+
+                    *file_count += manifest.added_files_count.unwrap_or(0) as usize;
+
+                    let Some((old_bounds, old_manifest)) = acc else {
+                        return Ok::<_, Error>(Some((bounds, manifest)));
+                    };
+
+                    match old_bounds.cmp_with_priority(&bounds)? {
+                        Ordering::Greater => {
+                            manifest_list_writer.append_ser(old_manifest)?;
+                            Ok(Some((bounds, manifest)))
+                        }
+                        _ => {
+                            manifest_list_writer.append_ser(manifest)?;
+                            Ok(Some((old_bounds, old_manifest)))
+                        }
+                    }
+                })?
+                .ok_or(Error::NotFound("Manifest".to_owned(), "file".to_owned()))?
+                .1
+        };
+    Ok(manifest)
 }

--- a/iceberg-rust/src/table/transaction/append.rs
+++ b/iceberg-rust/src/table/transaction/append.rs
@@ -5,7 +5,7 @@ use smallvec::{smallvec, SmallVec};
 
 use crate::{
     error::Error,
-    util::{cmp_with_priority, partition_struct_to_vec, sub, Rectangle},
+    util::{cmp_with_priority, partition_struct_to_vec, try_sub, Rectangle},
 };
 
 /// Split sets of datafiles depending on their partition_values
@@ -24,9 +24,10 @@ pub fn split_datafiles_once(
         let manifest_entry = manifest_entry?;
         let position = partition_struct_to_vec(manifest_entry.data_file().partition(), names)?;
         // Check distance to upper and lower bound
-        if let Ordering::Greater =
-            cmp_with_priority(&sub(&position, &rect.min)?, &sub(&rect.max, &position)?)?
-        {
+        if let Ordering::Greater = cmp_with_priority(
+            &try_sub(&position, &rect.min)?,
+            &try_sub(&rect.max, &position)?,
+        )? {
             // if closer to upper bound
             larger.push(manifest_entry);
 

--- a/iceberg-rust/src/table/transaction/append.rs
+++ b/iceberg-rust/src/table/transaction/append.rs
@@ -5,7 +5,7 @@ use smallvec::{smallvec, SmallVec};
 
 use crate::{
     error::Error,
-    util::{cmp_with_priority, struct_to_smallvec, sub, Rectangle},
+    util::{cmp_with_priority, partition_struct_to_vec, sub, Rectangle},
 };
 
 /// Split sets of datafiles depending on their partition_values
@@ -22,7 +22,7 @@ pub fn split_datafiles_once(
 
     for manifest_entry in files {
         let manifest_entry = manifest_entry?;
-        let position = struct_to_smallvec(manifest_entry.data_file().partition(), names)?;
+        let position = partition_struct_to_vec(manifest_entry.data_file().partition(), names)?;
         // Check distance to upper and lower bound
         if let Ordering::Greater =
             cmp_with_priority(&sub(&position, &rect.min)?, &sub(&rect.max, &position)?)?

--- a/iceberg-rust/src/table/transaction/append.rs
+++ b/iceberg-rust/src/table/transaction/append.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 /// Split sets of datafiles depending on their partition_values
+#[allow(clippy::type_complexity)]
 pub(crate) fn split_datafiles_once(
     files: impl Iterator<Item = Result<ManifestEntry, Error>>,
     rect: Rectangle<Value>,

--- a/iceberg-rust/src/table/transaction/append.rs
+++ b/iceberg-rust/src/table/transaction/append.rs
@@ -1,7 +1,6 @@
 use std::cmp::Ordering;
 
 use iceberg_rust_spec::manifest::ManifestEntry;
-use smallvec::{smallvec, SmallVec};
 
 use crate::{
     error::Error,
@@ -60,17 +59,17 @@ fn split_datafiles_once(
     ])
 }
 
-/// Splits the datafiles *n_split* times to decrease the number of datafiles per maniefst. 1 split returns 2 outputs vectors, 2 splits return 4, 3 splits return 8 and so on.
+/// Splits the datafiles *n_split* times to decrease the number of datafiles per maniefst. Returns *2^n_splits* lists of manifest entries.
 pub(crate) fn split_datafiles(
     files: impl Iterator<Item = Result<ManifestEntry, Error>>,
     rect: Rectangle,
     names: &[&str],
     n_split: u32,
-) -> Result<SmallVec<[Vec<ManifestEntry>; 2]>, Error> {
+) -> Result<Vec<Vec<ManifestEntry>>, Error> {
     let [(smaller, smaller_rect), (larger, larger_rect)] =
         split_datafiles_once(files, rect, names)?;
     if n_split == 1 {
-        Ok(smallvec![smaller, larger])
+        Ok(vec![smaller, larger])
     } else {
         let mut smaller = split_datafiles(
             smaller.into_iter().map(Ok),

--- a/iceberg-rust/src/table/transaction/append.rs
+++ b/iceberg-rust/src/table/transaction/append.rs
@@ -23,7 +23,8 @@ pub fn split_datafiles_once(
     for manifest_entry in files {
         let manifest_entry = manifest_entry?;
         let position = partition_struct_to_vec(manifest_entry.data_file().partition(), names)?;
-        // Check distance to upper and lower bound
+        // Compare distance to upper and lower bound. Since you can't compute a "norm" for a multidimensional vector where the dimensions have different datatypes,
+        // the dimensions are compared individually and the norm is computed by weighing the earlier columns more than the later.
         if let Ordering::Greater = cmp_with_priority(
             &try_sub(&position, &rect.min)?,
             &try_sub(&rect.max, &position)?,

--- a/iceberg-rust/src/table/transaction/append.rs
+++ b/iceberg-rust/src/table/transaction/append.rs
@@ -1,0 +1,83 @@
+use std::cmp::Ordering;
+
+use iceberg_rust_spec::{manifest::ManifestEntry, values::Value};
+use smallvec::{smallvec, SmallVec};
+
+use crate::{
+    error::Error,
+    util::{cmp_dist, struct_to_smallvec, sub, Rectangle},
+};
+
+/// Split sets of datafiles depending on their partition_values
+pub(crate) fn split_datafiles_once(
+    files: impl Iterator<Item = Result<ManifestEntry, Error>>,
+    rect: Rectangle<Value>,
+    names: &SmallVec<[&str; 4]>,
+) -> Result<[(Vec<ManifestEntry>, Rectangle<Value>); 2], Error> {
+    let mut smaller = Vec::new();
+    let mut larger = Vec::new();
+    let mut smaller_rect = None;
+    let mut larger_rect = None;
+
+    for manifest_entry in files {
+        let manifest_entry = manifest_entry?;
+        let position = struct_to_smallvec(manifest_entry.data_file().partition(), names)?;
+        // Check distance to upper and lower bound
+        if let Ordering::Greater =
+            cmp_dist(&sub(&position, &rect.min)?, &sub(&rect.max, &position)?)?
+        {
+            // if closer to upper bound
+            larger.push(manifest_entry);
+
+            if larger_rect.is_none() {
+                larger_rect = Some(Rectangle::new(position.clone(), position));
+            } else if let Some(larger_rect) = larger_rect.as_mut() {
+                larger_rect.expand_with_node(position);
+            }
+        } else {
+            // if closer to lower bound
+            smaller.push(manifest_entry);
+
+            if smaller_rect.is_none() {
+                smaller_rect = Some(Rectangle::new(position.clone(), position));
+            } else if let Some(smaller_rect) = smaller_rect.as_mut() {
+                smaller_rect.expand_with_node(position);
+            }
+        }
+    }
+    Ok([
+        (
+            smaller,
+            smaller_rect.ok_or(Error::NotFound("Lower".to_owned(), "rectangle".to_owned()))?,
+        ),
+        (
+            larger,
+            larger_rect.ok_or(Error::NotFound("Upper".to_owned(), "rectangle".to_owned()))?,
+        ),
+    ])
+}
+
+pub(crate) fn split_datafiles(
+    files: impl Iterator<Item = Result<ManifestEntry, Error>>,
+    rect: Rectangle<Value>,
+    names: &SmallVec<[&str; 4]>,
+    n_split: u32,
+) -> Result<SmallVec<[Vec<ManifestEntry>; 2]>, Error> {
+    let [(smaller, smaller_rect), (larger, larger_rect)] =
+        split_datafiles_once(files, rect, names)?;
+    if n_split == 1 {
+        Ok(smallvec![smaller, larger])
+    } else {
+        let mut smaller = split_datafiles(
+            smaller.into_iter().map(Ok),
+            smaller_rect,
+            names,
+            n_split - 1,
+        )?;
+        let mut larger =
+            split_datafiles(larger.into_iter().map(Ok), larger_rect, names, n_split - 1)?;
+
+        smaller.append(&mut larger);
+        Ok(smaller)
+    }
+}

--- a/iceberg-rust/src/table/transaction/append.rs
+++ b/iceberg-rust/src/table/transaction/append.rs
@@ -59,10 +59,11 @@ pub fn split_datafiles_once(
     ])
 }
 
+/// Splits the datafiles *n_split* times to decrease the number of datafiles per maniefst. 1 split returns 2 outputs vectors, 2 splits return 4, 3 splits return 8 and so on.
 pub(crate) fn split_datafiles(
     files: impl Iterator<Item = Result<ManifestEntry, Error>>,
     rect: Rectangle,
-    names: &SmallVec<[&str; 4]>,
+    names: &[&str],
     n_split: u32,
 ) -> Result<SmallVec<[Vec<ManifestEntry>; 2]>, Error> {
     let [(smaller, smaller_rect), (larger, larger_rect)] =

--- a/iceberg-rust/src/table/transaction/append.rs
+++ b/iceberg-rust/src/table/transaction/append.rs
@@ -4,7 +4,6 @@ use iceberg_rust_spec::{
     manifest::ManifestEntry,
     manifest_list::{ManifestListEntry, ManifestListReader},
 };
-use smallvec::SmallVec;
 
 use crate::{
     error::Error,
@@ -89,75 +88,85 @@ pub(crate) fn split_datafiles(
     }
 }
 
-/// Select the manifest that yields the smallest bounding rectangle after the bounding rectangle of the new values has been added.
-pub(crate) fn select_manifest(
-    partition_column_names: &SmallVec<[&str; 4]>,
-    mut manifest_list_reader: ManifestListReader<&[u8]>,
+/// Select the manifest that yields the smallest bounding rectangle after the
+/// bounding rectangle of the new values has been added.
+pub(crate) fn select_manifest_partitioned(
+    manifest_list_reader: ManifestListReader<&[u8]>,
     file_count: &mut usize,
     manifest_list_writer: &mut apache_avro::Writer<Vec<u8>>,
     bounding_partition_values: &Rectangle,
 ) -> Result<ManifestListEntry, Error> {
-    let manifest =
-        if partition_column_names.is_empty() {
-            // Find the manifest with the lowest row count
-            manifest_list_reader
-                .try_fold(None, |acc, x| {
-                    let manifest = x?;
+    let mut selected_state = None;
+    for manifest_res in manifest_list_reader {
+        let manifest = manifest_res?;
 
-                    let row_count = manifest.added_rows_count;
+        let mut bounds = summary_to_rectangle(
+            manifest
+                .partitions
+                .as_ref()
+                .ok_or(Error::NotFound("Partition".to_owned(), "struct".to_owned()))?,
+        )?;
 
-                    *file_count += manifest.added_files_count.unwrap_or(0) as usize;
+        bounds.expand(bounding_partition_values);
 
-                    let Some((old_row_count, old_manifest)) = acc else {
-                        return Ok::<_, Error>(Some((row_count, manifest)));
-                    };
+        *file_count += manifest.added_files_count.unwrap_or(0) as usize;
 
-                    let Some(row_count) = row_count else {
-                        return Ok(Some((old_row_count, old_manifest)));
-                    };
-
-                    if old_row_count.is_none() || old_row_count.is_some_and(|x| x > row_count) {
-                        manifest_list_writer.append_ser(old_manifest)?;
-                        Ok(Some((Some(row_count), manifest)))
-                    } else {
-                        manifest_list_writer.append_ser(manifest)?;
-                        Ok(Some((old_row_count, old_manifest)))
-                    }
-                })?
-                .ok_or(Error::NotFound("Manifest".to_owned(), "file".to_owned()))?
-                .1
-        } else {
-            // Find the manifest with the smallest bounding partition values
-            manifest_list_reader
-                .try_fold(None, |acc, x| {
-                    let manifest = x?;
-
-                    let mut bounds =
-                        summary_to_rectangle(manifest.partitions.as_ref().ok_or(
-                            Error::NotFound("Partition".to_owned(), "struct".to_owned()),
-                        )?)?;
-
-                    bounds.expand(bounding_partition_values);
-
-                    *file_count += manifest.added_files_count.unwrap_or(0) as usize;
-
-                    let Some((old_bounds, old_manifest)) = acc else {
-                        return Ok::<_, Error>(Some((bounds, manifest)));
-                    };
-
-                    match old_bounds.cmp_with_priority(&bounds)? {
-                        Ordering::Greater => {
-                            manifest_list_writer.append_ser(old_manifest)?;
-                            Ok(Some((bounds, manifest)))
-                        }
-                        _ => {
-                            manifest_list_writer.append_ser(manifest)?;
-                            Ok(Some((old_bounds, old_manifest)))
-                        }
-                    }
-                })?
-                .ok_or(Error::NotFound("Manifest".to_owned(), "file".to_owned()))?
-                .1
+        let Some((selected_bounds, selected_manifest)) = &selected_state else {
+            selected_state = Some((bounds, manifest));
+            continue;
         };
-    Ok(manifest)
+
+        match selected_bounds.cmp_with_priority(&bounds)? {
+            Ordering::Greater => {
+                manifest_list_writer.append_ser(selected_manifest)?;
+                selected_state = Some((bounds, manifest));
+                continue;
+            }
+            _ => {
+                manifest_list_writer.append_ser(manifest)?;
+                continue;
+            }
+        }
+    }
+    selected_state
+        .map(|(_, manifest)| manifest)
+        .ok_or(Error::NotFound("Manifest".to_owned(), "file".to_owned()))
+}
+
+/// Select the manifest with the smallest number of rows.
+pub(crate) fn select_manifest_unpartitioned(
+    manifest_list_reader: ManifestListReader<&[u8]>,
+    file_count: &mut usize,
+    manifest_list_writer: &mut apache_avro::Writer<Vec<u8>>,
+) -> Result<ManifestListEntry, Error> {
+    let mut selected_state = None;
+    for manifest_res in manifest_list_reader {
+        let manifest = manifest_res?;
+        // TODO: should this also account for existing_rows_count / existing_files_count?
+        let row_count = manifest.added_rows_count;
+        *file_count += manifest.added_files_count.unwrap_or(0) as usize;
+
+        let Some((selected_row_count, selected_manifest)) = &selected_state else {
+            selected_state = Some((row_count, manifest));
+            continue;
+        };
+
+        // If the file doesn't have any rows, we select it
+        let Some(row_count) = row_count else {
+            selected_state = Some((row_count, manifest));
+            continue;
+        };
+
+        if selected_row_count.is_some_and(|x| x > row_count) {
+            manifest_list_writer.append_ser(selected_manifest)?;
+            selected_state = Some((Some(row_count), manifest));
+            continue;
+        } else {
+            manifest_list_writer.append_ser(manifest)?;
+            continue;
+        }
+    }
+    selected_state
+        .map(|(_, manifest)| manifest)
+        .ok_or(Error::NotFound("Manifest".to_owned(), "file".to_owned()))
 }

--- a/iceberg-rust/src/table/transaction/mod.rs
+++ b/iceberg-rust/src/table/transaction/mod.rs
@@ -11,6 +11,7 @@ use self::operation::Operation;
 
 use super::delete_files;
 
+pub(crate) mod append;
 pub(crate) mod operation;
 
 pub(crate) static APPEND_KEY: &str = "append";
@@ -55,7 +56,7 @@ impl<'table> TableTransaction<'table> {
         self.operations
             .entry(APPEND_KEY.to_owned())
             .and_modify(|mut x| {
-                if let Operation::NewAppend {
+                if let Operation::Append {
                     branch: _,
                     files: old,
                     additional_summary: None,
@@ -64,7 +65,7 @@ impl<'table> TableTransaction<'table> {
                     old.extend_from_slice(&files)
                 }
             })
-            .or_insert(Operation::NewAppend {
+            .or_insert(Operation::Append {
                 branch: self.branch.clone(),
                 files,
                 additional_summary: None,

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -226,7 +226,9 @@ impl Operation {
                     .unwrap_or(0) as usize
                     + files.len();
 
-                // How many times do the files need to be split to give at most *limit* files per manifest
+                // To achieve fast lookups of the datafiles, the maniest tree should be somewhat balanced, meaning that manifest files should contain a similar number of datafiles.
+                // This means that maniest files might need to be split up when they get too large. Since the number of datafiles being added by a append operation might be really large,
+                // it might even be required to split the manifest file multiple times. *N_splits* stores how many times a manifest file needs to be split to give at most *limit* datafiles per manifest
                 let n_splits = match new_file_count / limit {
                     0 => 0,
                     x => x.ilog2() + 1,

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -29,7 +29,7 @@ use smallvec::SmallVec;
 use crate::{
     catalog::commit::{TableRequirement, TableUpdate},
     error::Error,
-    util::{struct_to_smallvec, summary_to_rectangle, Rectangle},
+    util::{partition_struct_to_vec, summary_to_rectangle, Rectangle},
 };
 
 use super::append::split_datafiles;
@@ -110,7 +110,7 @@ impl Operation {
                 let bounding_partition_values = files
                     .iter()
                     .try_fold(None, |acc, x| {
-                        let node = struct_to_smallvec(x.partition(), &partition_column_names)?;
+                        let node = partition_struct_to_vec(x.partition(), &partition_column_names)?;
                         let Some(mut acc) = acc else {
                             return Ok::<_, Error>(Some(Rectangle::new(node.clone(), node)));
                         };
@@ -560,7 +560,7 @@ impl Operation {
                 let bounding_partition_values = files
                     .iter()
                     .try_fold(None, |acc, x| {
-                        let node = struct_to_smallvec(x.partition(), &partition_column_names)?;
+                        let node = partition_struct_to_vec(x.partition(), &partition_column_names)?;
                         let Some(mut acc) = acc else {
                             return Ok::<_, Error>(Some(Rectangle::new(node.clone(), node)));
                         };

--- a/iceberg-rust/src/util/mod.rs
+++ b/iceberg-rust/src/util/mod.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, convert::identity};
+use std::cmp::Ordering;
 
 use iceberg_rust_spec::{
     manifest_list::FieldSummary,
@@ -70,7 +70,7 @@ impl Rectangle {
 pub(crate) fn struct_to_smallvec(s: &Struct, names: &[&str]) -> Result<Vec4<Value>, Error> {
     names
         .iter()
-        .map(|x| s.get(x).and_then(|x| identity(x).clone()))
+        .map(|x| s.get(x).and_then(Clone::clone))
         .collect::<Option<SmallVec<_>>>()
         .ok_or(Error::InvalidFormat("Partition struct".to_owned()))
 }

--- a/iceberg-rust/src/util/mod.rs
+++ b/iceberg-rust/src/util/mod.rs
@@ -142,6 +142,7 @@ pub(crate) fn sub<C: TrySub>(left: &[C], right: &[C]) -> Result<SmallVec<[C; 4]>
 #[cfg(test)]
 mod tests {
     use iceberg_rust_spec::values::Value;
+    use smallvec::smallvec;
 
     use super::*;
 
@@ -218,5 +219,69 @@ mod tests {
         let right = vec![1.0, 2.0];
         let result = cmp_dist(&left, &right);
         assert!(matches!(result, Err(Error::InvalidFormat(_))));
+    }
+    #[test]
+    fn test_rectangle_contains_empty() {
+        let container = Rectangle::<i32> {
+            min: smallvec![],
+            max: smallvec![],
+        };
+        let rect = Rectangle::<i32> {
+            min: smallvec![1, 2],
+            max: smallvec![3, 4],
+        };
+        assert!(!container.contains(&rect));
+    }
+
+    #[test]
+    fn test_rectangle_contains_true() {
+        let container = Rectangle::<i32> {
+            min: smallvec![0, 0],
+            max: smallvec![10, 10],
+        };
+        let rect = Rectangle::<i32> {
+            min: smallvec![2, 2],
+            max: smallvec![8, 8],
+        };
+        assert!(container.contains(&rect));
+    }
+
+    #[test]
+    fn test_rectangle_contains_false_min_boundary() {
+        let container = Rectangle::<i32> {
+            min: smallvec![1, 1],
+            max: smallvec![10, 10],
+        };
+        let rect = Rectangle::<i32> {
+            min: smallvec![0, 5],
+            max: smallvec![5, 8],
+        };
+        assert!(!container.contains(&rect));
+    }
+
+    #[test]
+    fn test_rectangle_contains_false_max_boundary() {
+        let container = Rectangle::<i32> {
+            min: smallvec![0, 0],
+            max: smallvec![10, 10],
+        };
+        let rect = Rectangle::<i32> {
+            min: smallvec![5, 5],
+            max: smallvec![11, 8],
+        };
+        assert!(!container.contains(&rect));
+    }
+
+    #[test]
+    fn test_rectangle_contains_higher_dimensions() {
+        let container = Rectangle::<i32> {
+            min: smallvec![0, 0, 0],
+            max: smallvec![10, 10, 10],
+        };
+        let rect = Rectangle::<i32> {
+            min: smallvec![1, 1, 1],
+            max: smallvec![9, 9, 9],
+        };
+        assert!(container.contains(&rect));
     }
 }

--- a/iceberg-rust/src/util/mod.rs
+++ b/iceberg-rust/src/util/mod.rs
@@ -1,0 +1,135 @@
+use std::{cmp::Ordering, convert::identity};
+
+use iceberg_rust_spec::{
+    manifest_list::FieldSummary,
+    values::{Struct, TryAdd, TrySub, Value},
+};
+use smallvec::SmallVec;
+
+use crate::error::Error;
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct Rectangle<C> {
+    pub min: SmallVec<[C; 4]>,
+    pub max: SmallVec<[C; 4]>,
+}
+
+impl<C> Rectangle<C>
+where
+    C: PartialOrd + Clone + TryAdd + TrySub,
+{
+    pub(crate) fn new(min: SmallVec<[C; 4]>, max: SmallVec<[C; 4]>) -> Self {
+        Self { min, max }
+    }
+
+    pub(crate) fn expand(&mut self, rect: &Rectangle<C>) {
+        for i in 0..self.min.len() {
+            if rect.min[i] < self.min[i] {
+                self.min[i] = rect.min[i].clone();
+            }
+            if rect.max[i] > self.max[i] {
+                self.max[i] = rect.max[i].clone();
+            }
+        }
+    }
+
+    pub(crate) fn expand_with_node(&mut self, node: SmallVec<[C; 4]>) {
+        for i in 0..self.min.len() {
+            if node[i] < self.min[i] {
+                self.min[i] = node[i].clone();
+            }
+            if node[i] > self.max[i] {
+                self.max[i] = node[i].clone();
+            }
+        }
+    }
+
+    /// Determine of one rectangle is larger than the other
+    pub(crate) fn cmp_with_priority(&self, other: &Rectangle<C>) -> Result<Ordering, Error> {
+        if self.contains(other) {
+            Ok(Ordering::Greater)
+        } else if other.contains(self) {
+            Ok(Ordering::Less)
+        } else {
+            let mut self_iter = self
+                .max
+                .iter()
+                .zip(self.min.iter())
+                .map(|(max, min)| max.try_sub(min));
+            let mut other_iter = other
+                .max
+                .iter()
+                .zip(other.min.iter())
+                .map(|(max, min)| max.try_sub(min));
+            while let (Some(own), Some(other)) = (self_iter.next(), other_iter.next()) {
+                let ordering = own?
+                    .partial_cmp(&other?)
+                    .ok_or(Error::InvalidFormat("Types for Partial Order".to_owned()))?;
+                let Ordering::Equal = ordering else {
+                    return Ok(ordering);
+                };
+            }
+            Ok(Ordering::Equal)
+        }
+    }
+
+    pub(crate) fn contains(&self, rect: &Rectangle<C>) -> bool {
+        if self.min.len() == 0 {
+            return false;
+        }
+        for i in 0..self.min.len() {
+            if rect.min[i] < self.min[i] || rect.max[i] > self.max[i] {
+                return false;
+            }
+        }
+        true
+    }
+
+    pub(crate) fn intersects(&self, rect: &Rectangle<C>) -> bool {
+        if self.min.len() == 0 {
+            return false;
+        }
+        for i in 0..self.min.len() {
+            if rect.min[i] > self.max[i] || rect.max[i] < self.min[i] {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+pub(crate) fn struct_to_smallvec(
+    s: &Struct,
+    names: &SmallVec<[&str; 4]>,
+) -> Result<SmallVec<[Value; 4]>, Error> {
+    names
+        .iter()
+        .map(|x| {
+            s.get(*x)
+                .and_then(|x| identity(x).as_ref().map(Clone::clone))
+        })
+        .collect::<Option<SmallVec<_>>>()
+        .ok_or(Error::InvalidFormat("Partition struct".to_owned()))
+}
+
+pub(crate) fn summary_to_rectangle(summaries: &[FieldSummary]) -> Result<Rectangle<Value>, Error> {
+    let mut max = SmallVec::with_capacity(summaries.len());
+    let mut min = SmallVec::with_capacity(summaries.len());
+
+    for summary in summaries {
+        max.push(
+            summary
+                .upper_bound
+                .clone()
+                .ok_or(Error::NotFound("Partition".to_owned(), "struct".to_owned()))?,
+        );
+        min.push(
+            summary
+                .lower_bound
+                .clone()
+                .ok_or(Error::NotFound("Partition".to_owned(), "struct".to_owned()))?,
+        );
+    }
+
+    Ok(Rectangle::new(min, max))
+}

--- a/iceberg-rust/src/util/mod.rs
+++ b/iceberg-rust/src/util/mod.rs
@@ -240,4 +240,39 @@ mod tests {
         let rect2 = Rectangle::new(smallvec![0, 2], smallvec![6, 6]);
         assert!(rect1.cmp_with_priority(&rect2).is_ok());
     }
+    #[test]
+    fn test_expand_with_node_smaller_values() {
+        let mut bounds = Rectangle::new(smallvec![5, 5, 5], smallvec![10, 10, 10]);
+        let node: SmallVec<[i32; 4]> = smallvec![3, 4, 2];
+        bounds.expand_with_node(node);
+        assert_eq!(bounds.min, smallvec![3, 4, 2] as SmallVec<[i32; 4]>);
+        assert_eq!(bounds.max, smallvec![10, 10, 10] as SmallVec<[i32; 4]>);
+    }
+
+    #[test]
+    fn test_expand_with_node_larger_values() {
+        let mut bounds = Rectangle::new(smallvec![5, 5, 5], smallvec![10, 10, 10]);
+        let node: SmallVec<[i32; 4]> = smallvec![6, 12, 11];
+        bounds.expand_with_node(node);
+        assert_eq!(bounds.min, smallvec![5, 5, 5] as SmallVec<[i32; 4]>);
+        assert_eq!(bounds.max, smallvec![10, 12, 11] as SmallVec<[i32; 4]>);
+    }
+
+    #[test]
+    fn test_expand_with_node_mixed_values() {
+        let mut bounds = Rectangle::new(smallvec![5, 5, 5], smallvec![10, 10, 10]);
+        let node: SmallVec<[i32; 4]> = smallvec![3, 15, 7];
+        bounds.expand_with_node(node);
+        assert_eq!(bounds.min, smallvec![3, 5, 5] as SmallVec<[i32; 4]>);
+        assert_eq!(bounds.max, smallvec![10, 15, 10] as SmallVec<[i32; 4]>);
+    }
+
+    #[test]
+    fn test_expand_with_node_equal_values() {
+        let mut bounds = Rectangle::new(smallvec![5, 5, 5], smallvec![10, 10, 10]);
+        let node: SmallVec<[i32; 4]> = smallvec![5, 10, 7];
+        bounds.expand_with_node(node);
+        assert_eq!(bounds.min, smallvec![5, 5, 5] as SmallVec<[i32; 4]>);
+        assert_eq!(bounds.max, smallvec![10, 10, 10] as SmallVec<[i32; 4]>);
+    }
 }

--- a/iceberg-rust/src/util/mod.rs
+++ b/iceberg-rust/src/util/mod.rs
@@ -275,4 +275,75 @@ mod tests {
         assert_eq!(bounds.min, smallvec![5, 5, 5] as SmallVec<[i32; 4]>);
         assert_eq!(bounds.max, smallvec![10, 10, 10] as SmallVec<[i32; 4]>);
     }
+    #[test]
+    fn test_rectangle_expand() {
+        let mut rect1 = Rectangle {
+            min: smallvec![0, 0],
+            max: smallvec![5, 5],
+        };
+
+        let rect2 = Rectangle {
+            min: smallvec![-1, -1],
+            max: smallvec![3, 6],
+        };
+
+        rect1.expand(&rect2);
+
+        assert_eq!(rect1.min, smallvec![-1, -1] as SmallVec<[i32; 4]>);
+        assert_eq!(rect1.max, smallvec![5, 6] as SmallVec<[i32; 4]>);
+    }
+
+    #[test]
+    fn test_rectangle_expand_no_change() {
+        let mut rect1 = Rectangle {
+            min: smallvec![0, 0],
+            max: smallvec![10, 10],
+        };
+
+        let rect2 = Rectangle {
+            min: smallvec![2, 2],
+            max: smallvec![8, 8],
+        };
+
+        rect1.expand(&rect2);
+
+        assert_eq!(rect1.min, smallvec![0, 0] as SmallVec<[i32; 4]>);
+        assert_eq!(rect1.max, smallvec![10, 10] as SmallVec<[i32; 4]>);
+    }
+
+    #[test]
+    fn test_rectangle_expand_single_dimension() {
+        let mut rect1 = Rectangle {
+            min: smallvec![5],
+            max: smallvec![10],
+        };
+
+        let rect2 = Rectangle {
+            min: smallvec![3],
+            max: smallvec![12],
+        };
+
+        rect1.expand(&rect2);
+
+        assert_eq!(rect1.min, smallvec![3] as SmallVec<[i32; 4]>);
+        assert_eq!(rect1.max, smallvec![12] as SmallVec<[i32; 4]>);
+    }
+
+    #[test]
+    fn test_rectangle_expand_empty() {
+        let mut rect1: Rectangle<i32> = Rectangle {
+            min: smallvec![],
+            max: smallvec![],
+        };
+
+        let rect2 = Rectangle {
+            min: smallvec![],
+            max: smallvec![],
+        };
+
+        rect1.expand(&rect2);
+
+        assert_eq!(rect1.min, smallvec![] as SmallVec<[i32; 4]>);
+        assert_eq!(rect1.max, smallvec![] as SmallVec<[i32; 4]>);
+    }
 }

--- a/iceberg-rust/src/util/mod.rs
+++ b/iceberg-rust/src/util/mod.rs
@@ -74,7 +74,7 @@ where
     }
 
     pub(crate) fn contains(&self, rect: &Rectangle<C>) -> bool {
-        if self.min.len() == 0 {
+        if self.min.is_empty() {
             return false;
         }
         for i in 0..self.min.len() {
@@ -93,8 +93,8 @@ pub(crate) fn struct_to_smallvec(
     names
         .iter()
         .map(|x| {
-            s.get(*x)
-                .and_then(|x| identity(x).as_ref().map(Clone::clone))
+            s.get(x)
+                .and_then(|x| identity(x).clone())
         })
         .collect::<Option<SmallVec<_>>>()
         .ok_or(Error::InvalidFormat("Partition struct".to_owned()))
@@ -125,7 +125,7 @@ pub(crate) fn summary_to_rectangle(summaries: &[FieldSummary]) -> Result<Rectang
 pub(crate) fn cmp_dist<C: PartialOrd>(left: &[C], right: &[C]) -> Result<Ordering, Error> {
     while let (Some(own), Some(other)) = (left.iter().next(), right.iter().next()) {
         let ordering = own
-            .partial_cmp(&other)
+            .partial_cmp(other)
             .ok_or(Error::InvalidFormat("Types for Partial Order".to_owned()))?;
         let Ordering::Equal = ordering else {
             return Ok(ordering);

--- a/iceberg-rust/src/util/mod.rs
+++ b/iceberg-rust/src/util/mod.rs
@@ -51,7 +51,9 @@ impl Rectangle {
         }
     }
 
-    /// Determine of one rectangle is larger than the other. Values the earlier columns more than the later.
+    /// Determine if one rectangle is larger than the other.
+    ///
+    ///Values the earlier columns more than the later.
     pub(crate) fn cmp_with_priority(&self, other: &Rectangle) -> Result<Ordering, Error> {
         let self_iter = self
             .max

--- a/iceberg-rust/src/util/mod.rs
+++ b/iceberg-rust/src/util/mod.rs
@@ -2,27 +2,26 @@ use std::{cmp::Ordering, convert::identity};
 
 use iceberg_rust_spec::{
     manifest_list::FieldSummary,
-    values::{Struct, TryAdd, TrySub, Value},
+    values::{Struct, TrySub, Value},
 };
 use smallvec::SmallVec;
 
 use crate::error::Error;
 
+type Vec4<T> = SmallVec<[T; 4]>;
+
 #[derive(Clone, PartialEq, Eq)]
-pub(crate) struct Rectangle<C> {
-    pub min: SmallVec<[C; 4]>,
-    pub max: SmallVec<[C; 4]>,
+pub(crate) struct Rectangle {
+    pub min: Vec4<Value>,
+    pub max: Vec4<Value>,
 }
 
-impl<C> Rectangle<C>
-where
-    C: PartialOrd + Ord + Clone + TryAdd + TrySub,
-{
-    pub(crate) fn new(min: SmallVec<[C; 4]>, max: SmallVec<[C; 4]>) -> Self {
+impl Rectangle {
+    pub(crate) fn new(min: Vec4<Value>, max: Vec4<Value>) -> Self {
         Self { min, max }
     }
 
-    pub(crate) fn expand(&mut self, rect: &Rectangle<C>) {
+    pub(crate) fn expand(&mut self, rect: &Rectangle) {
         for i in 0..self.min.len() {
             if rect.min[i] < self.min[i] {
                 self.min[i] = rect.min[i].clone();
@@ -33,7 +32,7 @@ where
         }
     }
 
-    pub(crate) fn expand_with_node(&mut self, node: SmallVec<[C; 4]>) {
+    pub(crate) fn expand_with_node(&mut self, node: Vec4<Value>) {
         for i in 0..self.min.len() {
             if node[i] < self.min[i] {
                 self.min[i] = node[i].clone();
@@ -45,7 +44,7 @@ where
     }
 
     /// Determine of one rectangle is larger than the other
-    pub(crate) fn cmp_with_priority(&self, other: &Rectangle<C>) -> Result<Ordering, Error> {
+    pub(crate) fn cmp_with_priority(&self, other: &Rectangle) -> Result<Ordering, Error> {
         let self_iter = self
             .max
             .iter()
@@ -68,10 +67,7 @@ where
     }
 }
 
-pub(crate) fn struct_to_smallvec(
-    s: &Struct,
-    names: &SmallVec<[&str; 4]>,
-) -> Result<SmallVec<[Value; 4]>, Error> {
+pub(crate) fn struct_to_smallvec(s: &Struct, names: &[&str]) -> Result<Vec4<Value>, Error> {
     names
         .iter()
         .map(|x| s.get(x).and_then(|x| identity(x).clone()))
@@ -79,7 +75,7 @@ pub(crate) fn struct_to_smallvec(
         .ok_or(Error::InvalidFormat("Partition struct".to_owned()))
 }
 
-pub(crate) fn summary_to_rectangle(summaries: &[FieldSummary]) -> Result<Rectangle<Value>, Error> {
+pub(crate) fn summary_to_rectangle(summaries: &[FieldSummary]) -> Result<Rectangle, Error> {
     let mut max = SmallVec::with_capacity(summaries.len());
     let mut min = SmallVec::with_capacity(summaries.len());
 
@@ -101,7 +97,7 @@ pub(crate) fn summary_to_rectangle(summaries: &[FieldSummary]) -> Result<Rectang
     Ok(Rectangle::new(min, max))
 }
 
-pub(crate) fn cmp_dist<C: PartialOrd>(left: &[C], right: &[C]) -> Result<Ordering, Error> {
+pub(crate) fn cmp_with_priority(left: &[Value], right: &[Value]) -> Result<Ordering, Error> {
     for (own, other) in left.iter().zip(right.iter()) {
         let ordering = own
             .partial_cmp(other)
@@ -113,7 +109,7 @@ pub(crate) fn cmp_dist<C: PartialOrd>(left: &[C], right: &[C]) -> Result<Orderin
     Ok(Ordering::Equal)
 }
 
-pub(crate) fn sub<C: TrySub>(left: &[C], right: &[C]) -> Result<SmallVec<[C; 4]>, Error> {
+pub(crate) fn sub(left: &[Value], right: &[Value]) -> Result<Vec4<Value>, Error> {
     let mut v = SmallVec::with_capacity(left.len());
     for i in 0..left.len() {
         v.push(left[i].try_sub(&right[i])?);
@@ -159,54 +155,44 @@ mod tests {
     #[test]
 
     fn test_cmp_dist_empty_slices() {
-        let result = cmp_dist::<i32>(&[], &[]);
+        let result = cmp_with_priority(&[], &[]);
         assert_eq!(result.unwrap(), Ordering::Equal);
     }
 
     #[test]
     fn test_cmp_dist_equal_slices() {
-        let left = vec![1, 2, 3];
-        let right = vec![1, 2, 3];
-        let result = cmp_dist(&left, &right);
+        let left = vec![Value::Int(1), Value::Int(2), Value::Int(3)];
+        let right = vec![Value::Int(1), Value::Int(2), Value::Int(3)];
+        let result = cmp_with_priority(&left, &right);
         assert_eq!(result.unwrap(), Ordering::Equal);
     }
 
     #[test]
     fn test_cmp_dist_less_than() {
-        let left = vec![1, 2];
-        let right = vec![1, 3];
-        let result = cmp_dist(&left, &right);
+        let left = vec![Value::Int(1), Value::Int(2)];
+        let right = vec![Value::Int(1), Value::Int(3)];
+        let result = cmp_with_priority(&left, &right);
         assert_eq!(result.unwrap(), Ordering::Less);
     }
 
     #[test]
     fn test_cmp_dist_greater_than() {
-        let left = vec![1, 4];
-        let right = vec![1, 3];
-        let result = cmp_dist(&left, &right);
+        let left = vec![Value::Int(1), Value::Int(4)];
+        let right = vec![Value::Int(1), Value::Int(3)];
+        let result = cmp_with_priority(&left, &right);
         assert_eq!(result.unwrap(), Ordering::Greater);
     }
 
     #[test]
-    fn test_cmp_dist_with_floats() {
-        let left = vec![1.0, 2.0];
-        let right = vec![1.0, 2.0];
-        let result = cmp_dist(&left, &right);
-        assert_eq!(result.unwrap(), Ordering::Equal);
-    }
-
-    #[test]
-    fn test_cmp_dist_with_nan() {
-        let left = vec![1.0, f64::NAN];
-        let right = vec![1.0, 2.0];
-        let result = cmp_dist(&left, &right);
-        assert!(matches!(result, Err(Error::InvalidFormat(_))));
-    }
-
-    #[test]
     fn test_rectangle_cmp_with_priority_greater() {
-        let larger = Rectangle::new(smallvec![0, 0], smallvec![10, 10]);
-        let smaller = Rectangle::new(smallvec![1, 1], smallvec![8, 8]);
+        let larger = Rectangle::new(
+            smallvec![Value::Int(0), Value::Int(0)],
+            smallvec![Value::Int(10), Value::Int(10)],
+        );
+        let smaller = Rectangle::new(
+            smallvec![Value::Int(1), Value::Int(1)],
+            smallvec![Value::Int(8), Value::Int(8)],
+        );
         assert_eq!(
             larger.cmp_with_priority(&smaller).unwrap(),
             Ordering::Greater
@@ -215,123 +201,195 @@ mod tests {
 
     #[test]
     fn test_rectangle_cmp_with_priority_less() {
-        let larger = Rectangle::new(smallvec![0, 0], smallvec![10, 10]);
-        let smaller = Rectangle::new(smallvec![1, 1], smallvec![8, 8]);
+        let larger = Rectangle::new(
+            smallvec![Value::Int(0), Value::Int(0)],
+            smallvec![Value::Int(10), Value::Int(10)],
+        );
+        let smaller = Rectangle::new(
+            smallvec![Value::Int(1), Value::Int(1)],
+            smallvec![Value::Int(8), Value::Int(8)],
+        );
         assert_eq!(smaller.cmp_with_priority(&larger).unwrap(), Ordering::Less);
     }
 
     #[test]
     fn test_rectangle_cmp_with_priority_equal() {
-        let rect1 = Rectangle::new(smallvec![0, 0], smallvec![5, 5]);
-        let rect2 = Rectangle::new(smallvec![0, 0], smallvec![5, 5]);
+        let rect1 = Rectangle::new(
+            smallvec![Value::Int(0), Value::Int(0)],
+            smallvec![Value::Int(5), Value::Int(5)],
+        );
+        let rect2 = Rectangle::new(
+            smallvec![Value::Int(0), Value::Int(0)],
+            smallvec![Value::Int(5), Value::Int(5)],
+        );
         assert_eq!(rect1.cmp_with_priority(&rect2).unwrap(), Ordering::Equal);
     }
 
     #[test]
     fn test_rectangle_cmp_with_priority_partial_dimensions() {
-        let rect1 = Rectangle::new(smallvec![0, 0], smallvec![6, 4]);
-        let rect2 = Rectangle::new(smallvec![0, 0], smallvec![4, 6]);
-        assert!(rect1.cmp_with_priority(&rect2).is_ok());
+        let rect1 = Rectangle::new(
+            smallvec![Value::Int(0), Value::Int(0)],
+            smallvec![Value::Int(6), Value::Int(4)],
+        );
+        let rect2 = Rectangle::new(
+            smallvec![Value::Int(0), Value::Int(0)],
+            smallvec![Value::Int(4), Value::Int(6)],
+        );
+        assert_eq!(rect1.cmp_with_priority(&rect2).unwrap(), Ordering::Greater);
     }
 
     #[test]
     fn test_rectangle_cmp_with_priority_overlapping() {
-        let rect1 = Rectangle::new(smallvec![2, 0], smallvec![8, 4]);
-        let rect2 = Rectangle::new(smallvec![0, 2], smallvec![6, 6]);
-        assert!(rect1.cmp_with_priority(&rect2).is_ok());
+        let rect1 = Rectangle::new(
+            smallvec![Value::Int(2), Value::Int(0)],
+            smallvec![Value::Int(8), Value::Int(4)],
+        );
+        let rect2 = Rectangle::new(
+            smallvec![Value::Int(0), Value::Int(2)],
+            smallvec![Value::Int(6), Value::Int(6)],
+        );
+        assert_eq!(rect1.cmp_with_priority(&rect2).unwrap(), Ordering::Equal);
     }
     #[test]
     fn test_expand_with_node_smaller_values() {
-        let mut bounds = Rectangle::new(smallvec![5, 5, 5], smallvec![10, 10, 10]);
-        let node: SmallVec<[i32; 4]> = smallvec![3, 4, 2];
+        let mut bounds = Rectangle::new(
+            smallvec![Value::Int(5), Value::Int(5), Value::Int(5)],
+            smallvec![Value::Int(10), Value::Int(10), Value::Int(10)],
+        );
+        let node: SmallVec<[Value; 4]> = smallvec![Value::Int(3), Value::Int(4), Value::Int(2)];
         bounds.expand_with_node(node);
-        assert_eq!(bounds.min, smallvec![3, 4, 2] as SmallVec<[i32; 4]>);
-        assert_eq!(bounds.max, smallvec![10, 10, 10] as SmallVec<[i32; 4]>);
+        assert_eq!(
+            bounds.min,
+            smallvec![Value::Int(3), Value::Int(4), Value::Int(2)] as SmallVec<[Value; 4]>
+        );
+        assert_eq!(
+            bounds.max,
+            smallvec![Value::Int(10), Value::Int(10), Value::Int(10)] as SmallVec<[Value; 4]>
+        );
     }
 
     #[test]
     fn test_expand_with_node_larger_values() {
-        let mut bounds = Rectangle::new(smallvec![5, 5, 5], smallvec![10, 10, 10]);
-        let node: SmallVec<[i32; 4]> = smallvec![6, 12, 11];
+        let mut bounds = Rectangle::new(
+            smallvec![Value::Int(5), Value::Int(5), Value::Int(5)],
+            smallvec![Value::Int(10), Value::Int(10), Value::Int(10)],
+        );
+        let node: SmallVec<[Value; 4]> = smallvec![Value::Int(6), Value::Int(12), Value::Int(11)];
         bounds.expand_with_node(node);
-        assert_eq!(bounds.min, smallvec![5, 5, 5] as SmallVec<[i32; 4]>);
-        assert_eq!(bounds.max, smallvec![10, 12, 11] as SmallVec<[i32; 4]>);
+        assert_eq!(
+            bounds.min,
+            smallvec![Value::Int(5), Value::Int(5), Value::Int(5)] as SmallVec<[Value; 4]>
+        );
+        assert_eq!(
+            bounds.max,
+            smallvec![Value::Int(10), Value::Int(12), Value::Int(11)] as SmallVec<[Value; 4]>
+        );
     }
 
     #[test]
     fn test_expand_with_node_mixed_values() {
-        let mut bounds = Rectangle::new(smallvec![5, 5, 5], smallvec![10, 10, 10]);
-        let node: SmallVec<[i32; 4]> = smallvec![3, 15, 7];
+        let mut bounds = Rectangle::new(
+            smallvec![Value::Int(5), Value::Int(5), Value::Int(5)],
+            smallvec![Value::Int(10), Value::Int(10), Value::Int(10)],
+        );
+        let node: SmallVec<[Value; 4]> = smallvec![Value::Int(3), Value::Int(15), Value::Int(7)];
         bounds.expand_with_node(node);
-        assert_eq!(bounds.min, smallvec![3, 5, 5] as SmallVec<[i32; 4]>);
-        assert_eq!(bounds.max, smallvec![10, 15, 10] as SmallVec<[i32; 4]>);
+        assert_eq!(
+            bounds.min,
+            smallvec![Value::Int(3), Value::Int(5), Value::Int(5)] as SmallVec<[Value; 4]>
+        );
+        assert_eq!(
+            bounds.max,
+            smallvec![Value::Int(10), Value::Int(15), Value::Int(10)] as SmallVec<[Value; 4]>
+        );
     }
 
     #[test]
     fn test_expand_with_node_equal_values() {
-        let mut bounds = Rectangle::new(smallvec![5, 5, 5], smallvec![10, 10, 10]);
-        let node: SmallVec<[i32; 4]> = smallvec![5, 10, 7];
+        let mut bounds = Rectangle::new(
+            smallvec![Value::Int(5), Value::Int(5), Value::Int(5)],
+            smallvec![Value::Int(10), Value::Int(10), Value::Int(10)],
+        );
+        let node: SmallVec<[Value; 4]> = smallvec![Value::Int(5), Value::Int(10), Value::Int(7)];
         bounds.expand_with_node(node);
-        assert_eq!(bounds.min, smallvec![5, 5, 5] as SmallVec<[i32; 4]>);
-        assert_eq!(bounds.max, smallvec![10, 10, 10] as SmallVec<[i32; 4]>);
+        assert_eq!(
+            bounds.min,
+            smallvec![Value::Int(5), Value::Int(5), Value::Int(5)] as SmallVec<[Value; 4]>
+        );
+        assert_eq!(
+            bounds.max,
+            smallvec![Value::Int(10), Value::Int(10), Value::Int(10)] as SmallVec<[Value; 4]>
+        );
     }
     #[test]
     fn test_rectangle_expand() {
         let mut rect1 = Rectangle {
-            min: smallvec![0, 0],
-            max: smallvec![5, 5],
+            min: smallvec![Value::Int(0), Value::Int(0)],
+            max: smallvec![Value::Int(5), Value::Int(5)],
         };
 
         let rect2 = Rectangle {
-            min: smallvec![-1, -1],
-            max: smallvec![3, 6],
+            min: smallvec![Value::Int(-1), Value::Int(-1)],
+            max: smallvec![Value::Int(3), Value::Int(6)],
         };
 
         rect1.expand(&rect2);
 
-        assert_eq!(rect1.min, smallvec![-1, -1] as SmallVec<[i32; 4]>);
-        assert_eq!(rect1.max, smallvec![5, 6] as SmallVec<[i32; 4]>);
+        assert_eq!(
+            rect1.min,
+            smallvec![Value::Int(-1), Value::Int(-1)] as SmallVec<[Value; 4]>
+        );
+        assert_eq!(
+            rect1.max,
+            smallvec![Value::Int(5), Value::Int(6)] as SmallVec<[Value; 4]>
+        );
     }
 
     #[test]
     fn test_rectangle_expand_no_change() {
         let mut rect1 = Rectangle {
-            min: smallvec![0, 0],
-            max: smallvec![10, 10],
+            min: smallvec![Value::Int(0), Value::Int(0)],
+            max: smallvec![Value::Int(10), Value::Int(10)],
         };
 
         let rect2 = Rectangle {
-            min: smallvec![2, 2],
-            max: smallvec![8, 8],
+            min: smallvec![Value::Int(2), Value::Int(2)],
+            max: smallvec![Value::Int(8), Value::Int(8)],
         };
 
         rect1.expand(&rect2);
 
-        assert_eq!(rect1.min, smallvec![0, 0] as SmallVec<[i32; 4]>);
-        assert_eq!(rect1.max, smallvec![10, 10] as SmallVec<[i32; 4]>);
+        assert_eq!(
+            rect1.min,
+            smallvec![Value::Int(0), Value::Int(0)] as SmallVec<[Value; 4]>
+        );
+        assert_eq!(
+            rect1.max,
+            smallvec![Value::Int(10), Value::Int(10)] as SmallVec<[Value; 4]>
+        );
     }
 
     #[test]
     fn test_rectangle_expand_single_dimension() {
         let mut rect1 = Rectangle {
-            min: smallvec![5],
-            max: smallvec![10],
+            min: smallvec![Value::Int(5)],
+            max: smallvec![Value::Int(10)],
         };
 
         let rect2 = Rectangle {
-            min: smallvec![3],
-            max: smallvec![12],
+            min: smallvec![Value::Int(3)],
+            max: smallvec![Value::Int(12)],
         };
 
         rect1.expand(&rect2);
 
-        assert_eq!(rect1.min, smallvec![3] as SmallVec<[i32; 4]>);
-        assert_eq!(rect1.max, smallvec![12] as SmallVec<[i32; 4]>);
+        assert_eq!(rect1.min, smallvec![Value::Int(3)] as SmallVec<[Value; 4]>);
+        assert_eq!(rect1.max, smallvec![Value::Int(12)] as SmallVec<[Value; 4]>);
     }
 
     #[test]
     fn test_rectangle_expand_empty() {
-        let mut rect1: Rectangle<i32> = Rectangle {
+        let mut rect1: Rectangle = Rectangle {
             min: smallvec![],
             max: smallvec![],
         };
@@ -343,7 +401,7 @@ mod tests {
 
         rect1.expand(&rect2);
 
-        assert_eq!(rect1.min, smallvec![] as SmallVec<[i32; 4]>);
-        assert_eq!(rect1.max, smallvec![] as SmallVec<[i32; 4]>);
+        assert_eq!(rect1.min, smallvec![] as SmallVec<[Value; 4]>);
+        assert_eq!(rect1.max, smallvec![] as SmallVec<[Value; 4]>);
     }
 }

--- a/iceberg-rust/src/util/mod.rs
+++ b/iceberg-rust/src/util/mod.rs
@@ -10,7 +10,7 @@ use crate::error::Error;
 
 type Vec4<T> = SmallVec<[T; 4]>;
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Rectangle {
     pub min: Vec4<Value>,
     pub max: Vec4<Value>,

--- a/iceberg-rust/src/util/mod.rs
+++ b/iceberg-rust/src/util/mod.rs
@@ -67,7 +67,8 @@ impl Rectangle {
     }
 }
 
-pub(crate) fn struct_to_smallvec(s: &Struct, names: &[&str]) -> Result<Vec4<Value>, Error> {
+/// Converts the values of a partition struct into a vector in the order that the columns appear in the partition spec
+pub(crate) fn partition_struct_to_vec(s: &Struct, names: &[&str]) -> Result<Vec4<Value>, Error> {
     names
         .iter()
         .map(|x| s.get(x).and_then(Clone::clone))


### PR DESCRIPTION
This PR improves the Append Operation in that it selects only a single manifest file to append the new datafiles to. In case the number of datafiles exceeds a certain threshold, the manifest file is split into smaller manifest files.

This should improve insert performance, as well as the overall structure of the manifest_list/manifest tree.