### PR TITLE
Move manifest list reader from spec crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,7 +2473,6 @@ dependencies = [
  "getrandom",
  "itertools 0.10.5",
  "murmur3",
- "object_store",
  "ordered-float 4.2.0",
  "rust_decimal",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde_derive = "^1.0"
 serde_json = "^1.0"
 futures = "0.3.30"
 async-trait = "0.1"
-chrono = { version = "0.4", default-features = false, features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 arrow = "52.1.0"
 arrow-schema = "52.1.0"
 datafusion = "40.0.0"
@@ -39,4 +39,3 @@ itertools = "0.10.5"
 derive-getters = "0.3.0"
 tracing = "0.1"
 tracing-futures = "0.2"
-

--- a/datafusion_iceberg/src/pruning_statistics.rs
+++ b/datafusion_iceberg/src/pruning_statistics.rs
@@ -3,13 +3,13 @@
  *
  * Pruning is done on two levels:
  *
- * 1. Prune ManifestFiles based on information in Manifest_list_file
- * 2. Prune DataFiles based on information in Manifest_file
+ * 1. Prune manifests based on information in manifests lists
+ * 2. Prune data files based on information in manifests
  *
- * For the first level the triat PruningStatistics is implemented for the DataFusionTable. It returns the pruning information for the manifest files
+ * For the first level the trait [`PruningStatistics`] is implemented for the DataFusionTable. It returns the pruning information for the manifest files
  * and not the final data files.
  *
- * For the second level the trait PruningStatistics is implemented for the ManifestFile
+ * For the second level the trait PruningStatistics is implemented for the Manifest
 */
 
 use std::any::Any;

--- a/iceberg-rust-spec/Cargo.toml
+++ b/iceberg-rust-spec/Cargo.toml
@@ -28,4 +28,3 @@ url = { workspace = true }
 derive_builder = "0.12.0"
 thiserror = { workspace = true }
 derive-getters = { workspace = true }
-object_store = { workspace = true }

--- a/iceberg-rust-spec/src/error.rs
+++ b/iceberg-rust-spec/src/error.rs
@@ -40,9 +40,6 @@ pub enum Error {
     /// Io error
     #[error(transparent)]
     IO(#[from] std::io::Error),
-    /// Objectstore error
-    #[error(transparent)]
-    ObjectStore(#[from] object_store::Error),
     /// Try from slice error
     #[error(transparent)]
     TryFromSlice(#[from] std::array::TryFromSliceError),

--- a/iceberg-rust-spec/src/spec/manifest_list.rs
+++ b/iceberg-rust-spec/src/spec/manifest_list.rs
@@ -651,12 +651,12 @@ pub fn manifest_list_schema_v2() -> &'static AvroSchema {
     })
 }
 
-/// Convert an avro value to a [ManifestFile] according to the provided format version
-pub fn avro_value_to_manifest_file(
-    value: (Result<AvroValue, apache_avro::Error>, &TableMetadata),
+/// Convert an avro value result to a manifest list version according to the provided format version
+pub fn avro_value_to_manifest_list_entry(
+    value: Result<AvroValue, apache_avro::Error>,
+    table_metadata: &TableMetadata,
 ) -> Result<ManifestListEntry, Error> {
-    let entry = value.0?;
-    let table_metadata = value.1;
+    let entry = value?;
     match table_metadata.format_version {
         FormatVersion::V1 => ManifestListEntry::try_from_v1(
             apache_avro::from_value::<_serde::ManifestListEntryV1>(&entry)?,

--- a/iceberg-rust-spec/src/spec/manifest_list.rs
+++ b/iceberg-rust-spec/src/spec/manifest_list.rs
@@ -2,13 +2,9 @@
  * Manifest lists
 */
 
-use std::{
-    io::Read,
-    iter::{repeat, Map, Repeat, Zip},
-    sync::OnceLock,
-};
+use std::sync::OnceLock;
 
-use apache_avro::{types::Value as AvroValue, Reader as AvroReader, Schema as AvroSchema};
+use apache_avro::{types::Value as AvroValue, Schema as AvroSchema};
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -22,39 +18,6 @@ use super::{
     types::Type,
     values::Value,
 };
-
-type ReaderZip<'a, 'metadata, R> = Zip<AvroReader<'a, R>, Repeat<&'metadata TableMetadata>>;
-type ReaderMap<'a, 'metadata, R> = Map<
-    ReaderZip<'a, 'metadata, R>,
-    fn((Result<AvroValue, apache_avro::Error>, &TableMetadata)) -> Result<ManifestListEntry, Error>,
->;
-
-/// Iterator of ManifestFileEntries
-pub struct ManifestListReader<'a, 'metadata, R: Read> {
-    reader: ReaderMap<'a, 'metadata, R>,
-}
-
-impl<'a, 'metadata, R: Read> Iterator for ManifestListReader<'a, 'metadata, R> {
-    type Item = Result<ManifestListEntry, Error>;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.reader.next()
-    }
-}
-
-impl<'a, 'metadata, R: Read> ManifestListReader<'a, 'metadata, R> {
-    /// Create a new ManifestFile reader
-    pub fn new(reader: R, table_metadata: &'metadata TableMetadata) -> Result<Self, Error> {
-        let schema: &AvroSchema = match table_metadata.format_version {
-            FormatVersion::V1 => manifest_list_schema_v1(),
-            FormatVersion::V2 => manifest_list_schema_v2(),
-        };
-        Ok(Self {
-            reader: AvroReader::with_schema(schema, reader)?
-                .zip(repeat(table_metadata))
-                .map(avro_value_to_manifest_file),
-        })
-    }
-}
 
 #[derive(Debug, Serialize, PartialEq, Eq, Clone)]
 #[serde(into = "ManifestListEntryEnum")]
@@ -300,7 +263,7 @@ impl ManifestListEntry {
         }
     }
 
-    pub(crate) fn try_from_v2(
+    pub fn try_from_v2(
         entry: _serde::ManifestListEntryV2,
         table_metadata: &TableMetadata,
     ) -> Result<ManifestListEntry, Error> {
@@ -344,7 +307,7 @@ impl ManifestListEntry {
         })
     }
 
-    pub(crate) fn try_from_v1(
+    pub fn try_from_v1(
         entry: _serde::ManifestListEntryV1,
         table_metadata: &TableMetadata,
     ) -> Result<ManifestListEntry, Error> {
@@ -689,7 +652,7 @@ pub fn manifest_list_schema_v2() -> &'static AvroSchema {
 }
 
 /// Convert an avro value to a [ManifestFile] according to the provided format version
-pub(crate) fn avro_value_to_manifest_file(
+pub fn avro_value_to_manifest_file(
     value: (Result<AvroValue, apache_avro::Error>, &TableMetadata),
 ) -> Result<ManifestListEntry, Error> {
     let entry = value.0?;

--- a/iceberg-rust-spec/src/spec/snapshot.rs
+++ b/iceberg-rust-spec/src/spec/snapshot.rs
@@ -3,24 +3,15 @@
 */
 use std::{
     collections::HashMap,
-    fmt,
-    io::Cursor,
-    str,
-    sync::Arc,
+    fmt, str,
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use derive_builder::Builder;
 use derive_getters::Getters;
-use object_store::ObjectStore;
 use serde::{Deserialize, Serialize};
 
-use crate::{error::Error, util};
-
-use super::{
-    manifest_list::{ManifestListEntry, ManifestListReader},
-    table_metadata::TableMetadata,
-};
+use crate::error::Error;
 
 use _serde::SnapshotEnum;
 
@@ -54,26 +45,6 @@ pub struct Snapshot {
     /// ID of the table’s current schema when the snapshot was created.
     #[builder(setter(strip_option), default)]
     schema_id: Option<i32>,
-}
-
-impl Snapshot {
-    // Return all manifest files associated to the latest table snapshot. Reads the related manifest_list file and returns its entries.
-    // If the manifest list file is empty returns an empty vector.
-    pub async fn manifests<'metadata>(
-        &self,
-        table_metadata: &'metadata TableMetadata,
-        object_store: Arc<dyn ObjectStore>,
-    ) -> Result<impl Iterator<Item = Result<ManifestListEntry, Error>> + 'metadata, Error> {
-        let bytes: Cursor<Vec<u8>> = Cursor::new(
-            object_store
-                .get(&util::strip_prefix(&self.manifest_list).into())
-                .await?
-                .bytes()
-                .await?
-                .into(),
-        );
-        ManifestListReader::new(bytes, table_metadata).map_err(Into::into)
-    }
 }
 
 pub fn generate_snapshot_id() -> i64 {

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -48,7 +48,7 @@ impl<'a, R: Read> Iterator for ManifestReader<'a, R> {
 }
 
 impl<'a, R: Read> ManifestReader<'a, R> {
-    /// Create a new ManifestReader reader
+    /// Create a new manifest reader
     pub fn new(reader: R) -> Result<Self, Error> {
         let reader = AvroReader::new(reader)?;
         let metadata = reader.user_metadata();

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -35,20 +35,20 @@ type ReaderMap<'a, R> = Map<
     ) -> Result<ManifestEntry, Error>,
 >;
 
-/// Iterator of ManifestFileEntries
-pub struct ManifestFileReader<'a, R: Read> {
+/// Iterator of manifest entries
+pub struct ManifestReader<'a, R: Read> {
     reader: ReaderMap<'a, R>,
 }
 
-impl<'a, R: Read> Iterator for ManifestFileReader<'a, R> {
+impl<'a, R: Read> Iterator for ManifestReader<'a, R> {
     type Item = Result<ManifestEntry, Error>;
     fn next(&mut self) -> Option<Self::Item> {
         self.reader.next()
     }
 }
 
-impl<'a, R: Read> ManifestFileReader<'a, R> {
-    /// Create a new ManifestFile reader
+impl<'a, R: Read> ManifestReader<'a, R> {
+    /// Create a new ManifestReader reader
     pub fn new(reader: R) -> Result<Self, Error> {
         let reader = AvroReader::new(reader)?;
         let metadata = reader.user_metadata();
@@ -103,13 +103,13 @@ impl<'a, R: Read> ManifestFileReader<'a, R> {
 }
 
 /// A helper to write entries into a manifest
-pub struct ManifestFileWriter<'schema, 'metadata> {
+pub struct ManifestWriter<'schema, 'metadata> {
     table_metadata: &'metadata TableMetadata,
     manifest: ManifestListEntry,
     writer: AvroWriter<'schema, Vec<u8>>,
 }
 
-impl<'schema, 'metadata> ManifestFileWriter<'schema, 'metadata> {
+impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
     /// Create empty manifest writer
     pub fn new(
         manifest_location: &str,
@@ -176,7 +176,7 @@ impl<'schema, 'metadata> ManifestFileWriter<'schema, 'metadata> {
             key_metadata: None,
         };
 
-        Ok(ManifestFileWriter {
+        Ok(ManifestWriter {
             manifest,
             writer,
             table_metadata,
@@ -234,7 +234,7 @@ impl<'schema, 'metadata> ManifestFileWriter<'schema, 'metadata> {
 
         writer.extend(manifest_reader.filter_map(Result::ok))?;
 
-        Ok(ManifestFileWriter {
+        Ok(ManifestWriter {
             manifest,
             writer,
             table_metadata,

--- a/iceberg-rust/src/table/manifest_file.rs
+++ b/iceberg-rust/src/table/manifest_file.rs
@@ -36,18 +36,18 @@ type ReaderMap<'a, R> = Map<
 >;
 
 /// Iterator of ManifestFileEntries
-pub struct ManifestReader<'a, R: Read> {
+pub struct ManifestFileReader<'a, R: Read> {
     reader: ReaderMap<'a, R>,
 }
 
-impl<'a, R: Read> Iterator for ManifestReader<'a, R> {
+impl<'a, R: Read> Iterator for ManifestFileReader<'a, R> {
     type Item = Result<ManifestEntry, Error>;
     fn next(&mut self) -> Option<Self::Item> {
         self.reader.next()
     }
 }
 
-impl<'a, R: Read> ManifestReader<'a, R> {
+impl<'a, R: Read> ManifestFileReader<'a, R> {
     /// Create a new ManifestFile reader
     pub fn new(reader: R) -> Result<Self, Error> {
         let reader = AvroReader::new(reader)?;
@@ -103,13 +103,13 @@ impl<'a, R: Read> ManifestReader<'a, R> {
 }
 
 /// A helper to write entries into a manifest
-pub struct ManifestWriter<'schema, 'metadata> {
+pub struct ManifestFileWriter<'schema, 'metadata> {
     table_metadata: &'metadata TableMetadata,
     manifest: ManifestListEntry,
     writer: AvroWriter<'schema, Vec<u8>>,
 }
 
-impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
+impl<'schema, 'metadata> ManifestFileWriter<'schema, 'metadata> {
     /// Create empty manifest writer
     pub fn new(
         manifest_location: &str,
@@ -176,7 +176,7 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             key_metadata: None,
         };
 
-        Ok(ManifestWriter {
+        Ok(ManifestFileWriter {
             manifest,
             writer,
             table_metadata,
@@ -234,7 +234,7 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
 
         writer.extend(manifest_reader.filter_map(Result::ok))?;
 
-        Ok(ManifestWriter {
+        Ok(ManifestFileWriter {
             manifest,
             writer,
             table_metadata,

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -1,0 +1,74 @@
+/*!
+ * Helpers to deal with manifest lists and files
+*/
+
+use std::{
+    io::{Cursor, Read},
+    iter::{repeat, Map, Repeat, Zip},
+    sync::Arc,
+};
+
+use apache_avro::{types::Value as AvroValue, Reader as AvroReader, Schema as AvroSchema};
+use iceberg_rust_spec::{
+    manifest_list::{
+        avro_value_to_manifest_file, manifest_list_schema_v1, manifest_list_schema_v2,
+        ManifestListEntry,
+    },
+    snapshot::Snapshot,
+    table_metadata::{FormatVersion, TableMetadata},
+    util::strip_prefix,
+};
+use object_store::ObjectStore;
+
+use crate::error::Error;
+
+type ReaderZip<'a, 'metadata, R> = Zip<AvroReader<'a, R>, Repeat<&'metadata TableMetadata>>;
+type ReaderMap<'a, 'metadata, R> = Map<
+    ReaderZip<'a, 'metadata, R>,
+    fn((Result<AvroValue, apache_avro::Error>, &TableMetadata)) -> Result<ManifestListEntry, Error>,
+>;
+
+/// Iterator of ManifestFileEntries
+pub struct ManifestListReader<'a, 'metadata, R: Read> {
+    reader: ReaderMap<'a, 'metadata, R>,
+}
+
+impl<'a, 'metadata, R: Read> Iterator for ManifestListReader<'a, 'metadata, R> {
+    type Item = Result<ManifestListEntry, Error>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.reader.next()
+    }
+}
+
+impl<'a, 'metadata, R: Read> ManifestListReader<'a, 'metadata, R> {
+    /// Create a new ManifestFile reader
+    pub fn new(reader: R, table_metadata: &'metadata TableMetadata) -> Result<Self, Error> {
+        let schema: &AvroSchema = match table_metadata.format_version {
+            FormatVersion::V1 => manifest_list_schema_v1(),
+            FormatVersion::V2 => manifest_list_schema_v2(),
+        };
+        Ok(Self {
+            reader: AvroReader::with_schema(schema, reader)?
+                .zip(repeat(table_metadata))
+                .map(|avro_res| avro_value_to_manifest_file(avro_res).map_err(Error::from)),
+        })
+    }
+}
+
+/// Return all manifest files associated to the latest table snapshot. Reads the related manifest_list file and returns its entries.
+/// If the manifest list file is empty returns an empty vector.
+pub(crate) async fn read_snapshot<'metadata>(
+    snapshot: &Snapshot,
+    table_metadata: &'metadata TableMetadata,
+    object_store: Arc<dyn ObjectStore>,
+) -> Result<impl Iterator<Item = Result<ManifestListEntry, Error>> + 'metadata, Error> {
+    let bytes: Cursor<Vec<u8>> = Cursor::new(
+        object_store
+            .get(&strip_prefix(snapshot.manifest_list()).into())
+            .await?
+            .bytes()
+            .await?
+            .into(),
+    );
+    ManifestListReader::new(bytes, table_metadata).map_err(Into::into)
+}

--- a/iceberg-rust/src/table/transaction/append.rs
+++ b/iceberg-rust/src/table/transaction/append.rs
@@ -1,12 +1,10 @@
 use std::cmp::Ordering;
 
-use iceberg_rust_spec::{
-    manifest::ManifestEntry,
-    manifest_list::{ManifestListEntry, ManifestListReader},
-};
+use iceberg_rust_spec::{manifest::ManifestEntry, manifest_list::ManifestListEntry};
 
 use crate::{
     error::Error,
+    table::manifest_list::ManifestListReader,
     util::{cmp_with_priority, partition_struct_to_vec, summary_to_rectangle, try_sub, Rectangle},
 };
 

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -18,7 +18,7 @@ use iceberg_rust_spec::util::strip_prefix;
 use object_store::ObjectStore;
 use smallvec::SmallVec;
 
-use crate::table::manifest_file::{ManifestFileReader, ManifestFileWriter};
+use crate::table::manifest::{ManifestReader, ManifestWriter};
 use crate::table::manifest_list::ManifestListReader;
 use crate::{
     catalog::commit::{TableRequirement, TableUpdate},
@@ -248,7 +248,7 @@ impl Operation {
                             .await?
                             .into();
 
-                        ManifestFileWriter::from_existing(
+                        ManifestWriter::from_existing(
                             &manifest_bytes,
                             manifest,
                             &manifest_schema,
@@ -263,7 +263,7 @@ impl Operation {
                             + &0.to_string()
                             + ".avro";
 
-                        ManifestFileWriter::new(
+                        ManifestWriter::new(
                             &manifest_location,
                             snapshot_id,
                             &manifest_schema,
@@ -289,8 +289,8 @@ impl Operation {
                             .await?
                             .into();
 
-                        let manifest_reader = ManifestFileReader::new(&*manifest_bytes)?
-                            .map(|x| x.map_err(Error::from));
+                        let manifest_reader =
+                            ManifestReader::new(&*manifest_bytes)?.map(|x| x.map_err(Error::from));
 
                         split_datafiles(
                             new_datafile_iter.chain(manifest_reader),
@@ -315,7 +315,7 @@ impl Operation {
                             + &i.to_string()
                             + ".avro";
 
-                        let mut manifest_writer = ManifestFileWriter::new(
+                        let mut manifest_writer = ManifestWriter::new(
                             &manifest_location,
                             snapshot_id,
                             &manifest_schema,
@@ -456,7 +456,7 @@ impl Operation {
                         + "-m"
                         + &0.to_string()
                         + ".avro";
-                    let mut manifest_writer = ManifestFileWriter::new(
+                    let mut manifest_writer = ManifestWriter::new(
                         &manifest_location,
                         snapshot_id,
                         &manifest_schema,
@@ -488,7 +488,7 @@ impl Operation {
                             + &i.to_string()
                             + ".avro";
 
-                        let mut manifest_writer = ManifestFileWriter::new(
+                        let mut manifest_writer = ManifestWriter::new(
                             &manifest_location,
                             snapshot_id,
                             &manifest_schema,

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -4,9 +4,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use iceberg_rust_spec::manifest_list::{
-    manifest_list_schema_v1, manifest_list_schema_v2, ManifestListReader,
-};
+use iceberg_rust_spec::manifest_list::{manifest_list_schema_v1, manifest_list_schema_v2};
 use iceberg_rust_spec::spec::table_metadata::TableMetadata;
 use iceberg_rust_spec::spec::{
     manifest::{partition_value_schema, DataFile, ManifestEntry, Status},
@@ -20,7 +18,8 @@ use iceberg_rust_spec::util::strip_prefix;
 use object_store::ObjectStore;
 use smallvec::SmallVec;
 
-use crate::table::manifest::{ManifestReader, ManifestWriter};
+use crate::table::manifest_file::{ManifestFileReader, ManifestFileWriter};
+use crate::table::manifest_list::ManifestListReader;
 use crate::{
     catalog::commit::{TableRequirement, TableUpdate},
     error::Error,
@@ -249,7 +248,7 @@ impl Operation {
                             .await?
                             .into();
 
-                        ManifestWriter::from_existing(
+                        ManifestFileWriter::from_existing(
                             &manifest_bytes,
                             manifest,
                             &manifest_schema,
@@ -264,7 +263,7 @@ impl Operation {
                             + &0.to_string()
                             + ".avro";
 
-                        ManifestWriter::new(
+                        ManifestFileWriter::new(
                             &manifest_location,
                             snapshot_id,
                             &manifest_schema,
@@ -290,8 +289,8 @@ impl Operation {
                             .await?
                             .into();
 
-                        let manifest_reader =
-                            ManifestReader::new(&*manifest_bytes)?.map(|x| x.map_err(Error::from));
+                        let manifest_reader = ManifestFileReader::new(&*manifest_bytes)?
+                            .map(|x| x.map_err(Error::from));
 
                         split_datafiles(
                             new_datafile_iter.chain(manifest_reader),
@@ -316,7 +315,7 @@ impl Operation {
                             + &i.to_string()
                             + ".avro";
 
-                        let mut manifest_writer = ManifestWriter::new(
+                        let mut manifest_writer = ManifestFileWriter::new(
                             &manifest_location,
                             snapshot_id,
                             &manifest_schema,
@@ -457,7 +456,7 @@ impl Operation {
                         + "-m"
                         + &0.to_string()
                         + ".avro";
-                    let mut manifest_writer = ManifestWriter::new(
+                    let mut manifest_writer = ManifestFileWriter::new(
                         &manifest_location,
                         snapshot_id,
                         &manifest_schema,
@@ -489,7 +488,7 @@ impl Operation {
                             + &i.to_string()
                             + ".avro";
 
-                        let mut manifest_writer = ManifestWriter::new(
+                        let mut manifest_writer = ManifestFileWriter::new(
                             &manifest_location,
                             snapshot_id,
                             &manifest_schema,


### PR DESCRIPTION
The manifest list reader should be in the same crate as the manifest file reader (main iceberg-rust).