### PR TITLE
Add makefile

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,11 +17,11 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run iceberg-rust-spec tests
-      run: cargo test -p iceberg-rust-spec --lib --verbose
+      run: make test-iceberg-rust-spec
     - name: Run iceberg-rust tests
-      run: cargo test -p iceberg-rust --lib --verbose
+      run: make test-iceberg-rust
     - name: Run datafusion-iceberg tests
-      run: cargo test -p datafusion_iceberg --tests --verbose -j 2
+      run: make test-datafusion_iceberg
 
   lint:
     runs-on: ubuntu-latest
@@ -30,4 +30,4 @@ jobs:
     - name: Install Clippy
       run: rustup component add clippy
     - name: Run Clippy
-      run: cargo clippy --all-targets --all-features -- -D warnings
+      run: make clippy

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+test: test-iceberg-rust-spec test-iceberg-rust test-datafusion_iceberg
+
+test-iceberg-rust-spec:
+	cargo test -p iceberg-rust-spec --lib
+
+test-iceberg-rust:
+	cargo test -p iceberg-rust --lib
+
+test-datafusion_iceberg:
+	cargo test -p datafusion_iceberg --tests -j 2
+
+clippy:
+	cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
It is convinient to have a Makefile that shows the developer commands / git hooks that are expected to be used and that are also executed by the CI.