### PR TITLE
Fix sequence number and file counts

### DIFF
--- a/iceberg-rust-spec/src/spec/manifest.rs
+++ b/iceberg-rust-spec/src/spec/manifest.rs
@@ -240,7 +240,7 @@ impl ManifestEntry {
     }
 }
 
-#[derive(Debug, Serialize_repr, Deserialize_repr, PartialEq, Eq, Clone)]
+#[derive(Debug, Serialize_repr, Deserialize_repr, PartialEq, Eq, Clone, Copy)]
 #[repr(u8)]
 /// Used to track additions and deletions
 pub enum Status {

--- a/iceberg-rust-spec/src/spec/manifest.rs
+++ b/iceberg-rust-spec/src/spec/manifest.rs
@@ -48,6 +48,10 @@ impl ManifestEntry {
     pub fn status_mut(&mut self) -> &mut Status {
         &mut self.status
     }
+
+    pub fn sequence_number_mut(&mut self) -> &mut Option<i64> {
+        &mut self.sequence_number
+    }
 }
 
 impl ManifestEntry {

--- a/iceberg-rust-spec/src/spec/table_metadata.rs
+++ b/iceberg-rust-spec/src/spec/table_metadata.rs
@@ -273,6 +273,13 @@ impl TableMetadata {
             }
         }
     }
+
+    /// Get sequence_number of snapshot
+    pub fn sequence_number(&self, snapshot_id: i64) -> Option<i64> {
+        self.snapshots
+            .get(&snapshot_id)
+            .map(|x| *x.sequence_number())
+    }
 }
 
 pub fn new_metadata_location<'a, T: Into<TabularMetadataRef<'a>>>(metadata: T) -> String {

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -261,6 +261,14 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
                     let mut entry = entry
                         .map_err(|err| apache_avro::Error::DeserializeValue(err.to_string()))?;
                     *entry.status_mut() = Status::Existing;
+                    if entry.sequence_number().is_none() {
+                        *entry.sequence_number_mut() =
+                            table_metadata.sequence_number(entry.snapshot_id().ok_or(
+                                apache_avro::Error::DeserializeValue(
+                                    "Snapshot_id missing in Manifest Entry.".to_owned(),
+                                ),
+                            )?);
+                    }
                     to_value(entry)
                 })
                 .filter_map(Result::ok),

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -198,7 +198,7 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
     /// Create an manifest writer from an existing manifest
     pub fn from_existing(
         bytes: &[u8],
-        manifest: ManifestListEntry,
+        mut manifest: ManifestListEntry,
         schema: &'schema AvroSchema,
         table_metadata: &'metadata TableMetadata,
         branch: Option<&str>,
@@ -274,6 +274,12 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
                 .filter_map(Result::ok),
         )?;
 
+        manifest.existing_files_count = Some(
+            manifest.existing_files_count.unwrap_or(0) + manifest.added_files_count.unwrap_or(0),
+        );
+
+        manifest.added_files_count = None;
+
         Ok(ManifestWriter {
             manifest,
             writer,
@@ -302,6 +308,8 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         }
 
         added_rows_count += manifest_entry.data_file().record_count();
+        let status = *manifest_entry.status();
+
         update_partitions(
             self.manifest.partitions.as_mut().unwrap(),
             manifest_entry.data_file().partition(),
@@ -310,10 +318,22 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
 
         self.writer.append_ser(manifest_entry)?;
 
-        self.manifest.added_files_count = match self.manifest.added_files_count {
-            Some(count) => Some(count + 1),
-            None => Some(1),
-        };
+        match status {
+            Status::Added => {
+                self.manifest.added_files_count = match self.manifest.added_files_count {
+                    Some(count) => Some(count + 1),
+                    None => Some(1),
+                };
+            }
+            Status::Existing => {
+                self.manifest.existing_files_count = match self.manifest.existing_files_count {
+                    Some(count) => Some(count + 1),
+                    None => Some(1),
+                };
+            }
+            Status::Deleted => (),
+        }
+
         self.manifest.added_rows_count = match self.manifest.added_rows_count {
             Some(count) => Some(count + added_rows_count),
             None => Some(added_rows_count),

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -166,9 +166,19 @@ impl Operation {
 
                 let selected_manifest_file_count = selected_manifest_opt
                     .as_ref()
-                    // TODO: should this also account for existing_files_count?
-                    .and_then(|selected_manifest| selected_manifest.added_files_count)
+                    .and_then(|selected_manifest| {
+                        match (
+                            selected_manifest.existing_files_count,
+                            selected_manifest.added_files_count,
+                        ) {
+                            (Some(x), Some(y)) => Some(x + y),
+                            (Some(x), None) => Some(x),
+                            (None, Some(y)) => Some(y),
+                            (None, None) => None,
+                        }
+                    })
                     .unwrap_or(0) as usize;
+
                 let n_splits = compute_n_splits(
                     existing_file_count,
                     new_files.len(),


### PR DESCRIPTION
This PR makes sure the sequence number only gets assigned after the snapshot has been committed.

Additionally it fixes the added and existing file counts.