### PR TITLE
Bugfix/glue contract

### DIFF
--- a/catalogs/iceberg-glue-catalog/src/lib.rs
+++ b/catalogs/iceberg-glue-catalog/src/lib.rs
@@ -314,7 +314,7 @@ impl Catalog for GlueCatalog {
                             .set_columns(schema_to_glue(schema.fields()).ok())
                             .build()
                     )
-                    .set_parameters(Some(get_parameters(metadata_location)))
+                    .set_parameters(Some(get_parameters(&metadata_location)))
                     .build()
                     .map_err(Error::from)?,
             )
@@ -677,7 +677,7 @@ impl Catalog for GlueCatalog {
                 TableInput::builder()
                     .name(identifier.name())
                     .set_parameters(
-                        Some(get_parameters(metadata_location))
+                        Some(get_parameters(&metadata_location))
                     )
                     .build()
                     .map_err(Error::from)?,
@@ -782,7 +782,7 @@ impl Catalog for GlueCatalog {
                 TableInput::builder()
                     .name(identifier.name())
                     .set_parameters(
-                    Some(get_parameters(metadata_location))
+                    Some(get_parameters(&metadata_location))
                     )
                     .build()
                     .map_err(Error::from)?,

--- a/catalogs/iceberg-glue-catalog/src/lib.rs
+++ b/catalogs/iceberg-glue-catalog/src/lib.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+use crate::utils::{get_parameters, METADATA_LOCATION};
 use async_trait::async_trait;
 use aws_config::SdkConfig;
 use aws_sdk_glue::{
@@ -38,7 +39,6 @@ use iceberg_rust::{
 };
 use object_store::ObjectStore;
 use schema::schema_to_glue;
-use crate::utils::{get_parameters, METADATA_LOCATION};
 
 use crate::error::Error;
 
@@ -241,9 +241,13 @@ impl Catalog for GlueCatalog {
                 "Glue create table didn't return a table.".to_owned(),
             ))?;
 
-        let metadata_location = table.parameters().
-            and_then(|parameter| parameter.get(METADATA_LOCATION))
-            .ok_or(IcebergError::NotFound(format!("Glue table {} metadata location not found", &table.name())))?;
+        let metadata_location = table
+            .parameters()
+            .and_then(|parameter| parameter.get(METADATA_LOCATION))
+            .ok_or(IcebergError::NotFound(format!(
+                "Glue table {} metadata location not found",
+                &table.name()
+            )))?;
 
         let version_id = table
             .version_id()
@@ -308,13 +312,13 @@ impl Catalog for GlueCatalog {
             .table_input(
                 TableInput::builder()
                     .name(identifier.name())
+                    .set_parameters(Some(get_parameters(&metadata_location)))
                     .storage_descriptor(
                         StorageDescriptor::builder()
                             .location(&location)
                             .set_columns(schema_to_glue(schema.fields()).ok())
-                            .build()
+                            .build(),
                     )
-                    .set_parameters(Some(get_parameters(&metadata_location)))
                     .build()
                     .map_err(Error::from)?,
             )
@@ -378,9 +382,10 @@ impl Catalog for GlueCatalog {
             .table_input(
                 TableInput::builder()
                     .name(identifier.name())
+                    .set_parameters(Some(get_parameters(&metadata_location)))
                     .storage_descriptor(
                         StorageDescriptor::builder()
-                            .location(&metadata_location)
+                            .location(&location)
                             .set_columns(schema_to_glue(schema.fields()).ok())
                             .build(),
                     )
@@ -459,9 +464,10 @@ impl Catalog for GlueCatalog {
             .table_input(
                 TableInput::builder()
                     .name(identifier.name())
+                    .set_parameters(Some(get_parameters(&metadata_location)))
                     .storage_descriptor(
                         StorageDescriptor::builder()
-                            .location(&metadata_location)
+                            .location(&location)
                             .set_columns(schema_to_glue(schema.fields()).ok())
                             .build(),
                     )
@@ -479,9 +485,10 @@ impl Catalog for GlueCatalog {
             .table_input(
                 TableInput::builder()
                     .name(table_identifier.name())
+                    .set_parameters(Some(get_parameters(&table_metadata_location)))
                     .storage_descriptor(
                         StorageDescriptor::builder()
-                            .location(&table_metadata_location)
+                            .location(&location)
                             .set_columns(schema_to_glue(table_schema.fields()).ok())
                             .build(),
                     )
@@ -567,9 +574,10 @@ impl Catalog for GlueCatalog {
             .table_input(
                 TableInput::builder()
                     .name(identifier.name())
+                    .set_parameters(Some(get_parameters(&metadata_location)))
                     .storage_descriptor(
                         StorageDescriptor::builder()
-                            .location(&metadata_location)
+                            .location(&metadata.location)
                             .set_columns(schema_to_glue(schema.fields()).ok())
                             .build(),
                     )
@@ -601,14 +609,14 @@ impl Catalog for GlueCatalog {
             .to_string();
 
         let new_metadata_location = table
-            .storage_descriptor()
-            .and_then(|x| x.location())
+            .parameters()
+            .and_then(|parameter| parameter.get(METADATA_LOCATION))
             .ok_or(IcebergError::NotFound(format!(
                 "Location for table {} not found.",
                 identifier.name()
             )))?;
 
-        let metadata = if new_metadata_location == metadata_location {
+        let metadata = if new_metadata_location == &metadata_location {
             metadata
         } else {
             let bytes = object_store
@@ -676,8 +684,12 @@ impl Catalog for GlueCatalog {
             .table_input(
                 TableInput::builder()
                     .name(identifier.name())
-                    .set_parameters(
-                        Some(get_parameters(&metadata_location))
+                    .set_parameters(Some(get_parameters(&metadata_location)))
+                    .storage_descriptor(
+                        StorageDescriptor::builder()
+                            .location(metadata_ref.location())
+                            .set_columns(schema_to_glue(schema.fields()).ok())
+                            .build(),
                     )
                     .build()
                     .map_err(Error::from)?,
@@ -707,14 +719,14 @@ impl Catalog for GlueCatalog {
             .to_string();
 
         let new_metadata_location = table
-            .storage_descriptor()
-            .and_then(|x| x.location())
+            .parameters()
+            .and_then(|parameter| parameter.get(METADATA_LOCATION))
             .ok_or(IcebergError::NotFound(format!(
                 "Location for table {} not found.",
                 identifier.name()
             )))?;
 
-        let metadata = if new_metadata_location == metadata_location {
+        let metadata = if new_metadata_location == &metadata_location {
             metadata
         } else {
             object_store.get_metadata(new_metadata_location).await?
@@ -781,8 +793,12 @@ impl Catalog for GlueCatalog {
             .table_input(
                 TableInput::builder()
                     .name(identifier.name())
-                    .set_parameters(
-                    Some(get_parameters(&metadata_location))
+                    .set_parameters(Some(get_parameters(&metadata_location)))
+                    .storage_descriptor(
+                        StorageDescriptor::builder()
+                            .location(metadata_ref.location())
+                            .set_columns(schema_to_glue(schema.fields()).ok())
+                            .build(),
                     )
                     .build()
                     .map_err(Error::from)?,
@@ -812,14 +828,14 @@ impl Catalog for GlueCatalog {
             .to_string();
 
         let new_metadata_location = table
-            .storage_descriptor()
-            .and_then(|x| x.location())
+            .parameters()
+            .and_then(|parameter| parameter.get(METADATA_LOCATION))
             .ok_or(IcebergError::NotFound(format!(
                 "Location for table {} not found.",
                 identifier.name()
             )))?;
 
-        let metadata = if new_metadata_location == metadata_location {
+        let metadata = if new_metadata_location == &metadata_location {
             metadata
         } else {
             object_store.get_metadata(new_metadata_location).await?
@@ -868,13 +884,7 @@ impl Catalog for GlueCatalog {
                             .set_columns(schema_to_glue(schema.fields()).ok())
                             .build(),
                     )
-                    .set_parameters(
-                        Some(
-                            HashMap::from([
-
-                            ])
-                        )
-                    )
+                    .set_parameters(Some(HashMap::from([])))
                     .build()
                     .map_err(Error::from)?,
             )

--- a/catalogs/iceberg-glue-catalog/src/utils.rs
+++ b/catalogs/iceberg-glue-catalog/src/utils.rs
@@ -1,0 +1,16 @@
+use std::collections::HashMap;
+
+/// Property `metadata_location` for `TableInput`
+pub(crate) const METADATA_LOCATION: &str = "metadata_location";
+/// Parameter key `table_type` for `TableInput`
+pub(crate) const TABLE_TYPE: &str = "table_type";
+/// Parameter value `table_type` for `TableInput`
+pub(crate) const ICEBERG: &str = "ICEBERG";
+
+pub(crate) fn get_parameters (metadata_location: String) -> HashMap<String, String> {
+    HashMap::from([
+        (TABLE_TYPE.to_string(), ICEBERG.to_string()),
+        (METADATA_LOCATION.to_string(), metadata_location)
+    ])
+}
+

--- a/catalogs/iceberg-glue-catalog/src/utils.rs
+++ b/catalogs/iceberg-glue-catalog/src/utils.rs
@@ -7,10 +7,10 @@ pub(crate) const TABLE_TYPE: &str = "table_type";
 /// Parameter value `table_type` for `TableInput`
 pub(crate) const ICEBERG: &str = "ICEBERG";
 
-pub(crate) fn get_parameters (metadata_location: String) -> HashMap<String, String> {
+pub(crate) fn get_parameters (metadata_location: &str) -> HashMap<String, String> {
     HashMap::from([
         (TABLE_TYPE.to_string(), ICEBERG.to_string()),
-        (METADATA_LOCATION.to_string(), metadata_location)
+        (METADATA_LOCATION.to_string(), metadata_location.to_string())
     ])
 }
 


### PR DESCRIPTION
- This Repo's implementation of Glue Catalog is different from Iceberg Java implementation. 
The Java Implementation persisted the metadata file path in parameters, where as this implementation is persisting it in StorageDescriptor. 
