### PR TITLE
Extend support for parsing decimal types and values

### DIFF
--- a/iceberg-rust-spec/src/spec/types.rs
+++ b/iceberg-rust-spec/src/spec/types.rs
@@ -1,13 +1,13 @@
 /*!
  * Iceberg type system implementation
- * 
+ *
  * This module implements Iceberg's type system, which includes:
- * 
+ *
  * - Primitive types: boolean, numeric types, strings, binary, etc.
  * - Complex types: structs, lists, and maps
  * - Type conversion and validation logic
  * - Serialization/deserialization support
- * 
+ *
  * The type system is used throughout the Iceberg format to:
  * - Define table schemas
  * - Validate data values
@@ -136,7 +136,7 @@ where
 
     Ok(PrimitiveType::Decimal {
         precision: precision.parse().map_err(D::Error::custom)?,
-        scale: scale.parse().map_err(D::Error::custom)?,
+        scale: scale.trim().parse().map_err(D::Error::custom)?,
     })
 }
 


### PR DESCRIPTION
This PR extends support for decimal types, enabling full TPC-H benchmarking with this crate.

The changes include:
- Fix for deserializing a decimal type with a space before the scale (e.g. `decimal(15, 2)`), as is output by pyiceberg
- Parsing of the byte value to the corresponding decimal stat value