### PR TITLE
Update data validation logic to match changes in lineitem.csv

### DIFF
--- a/datafusion_iceberg/examples/insert_csv.rs
+++ b/datafusion_iceberg/examples/insert_csv.rs
@@ -142,7 +142,7 @@ async fn main() {
                 if product_id.unwrap() == 24027 {
                     assert_eq!(amount.unwrap(), 24.0)
                 } else if product_id.unwrap() == 63700 {
-                    assert_eq!(amount.unwrap(), 8.0)
+                    assert_eq!(amount.unwrap(), 23.0)
                 }
             }
             once = true


### PR DESCRIPTION
Since there are several more data with L_PARTKEY=63700 in the datafusion_iceberg/testdata/tpch/lineitem.csv file, the sum(L_QUANTITY) result in insert_csv.rs changes to 23.0:

```csv
1,63700,3701,3,8,13309.60,0.10,0.02,N,O,"1996-01-29","1996-03-05","1996-01-31","TAKE BACK RETURN","REG AIR","riously. regular, express dep"
27751,63700,6207,5,14,23291.80,0.07,0.05,N,O,"1998-06-17","1998-06-01","1998-06-26","COLLECT COD","REG AIR"," final, even requests among"
42721,63700,1219,2,1,1663.70,0.00,0.07,N,O,"1997-03-23","1997-01-28","1997-04-09","NONE","TRUCK","ounts. slyly ironic packages sleep quickly "
```

It should be 8+14+1=23