### PR TITLE
Convert Arrow Int8 and Int16 to Iceberg Int

### DIFF
--- a/iceberg-rust-spec/src/arrow/schema.rs
+++ b/iceberg-rust-spec/src/arrow/schema.rs
@@ -146,7 +146,9 @@ impl TryFrom<&DataType> for Type {
     fn try_from(value: &DataType) -> Result<Self, Self::Error> {
         match value {
             DataType::Boolean => Ok(Type::Primitive(PrimitiveType::Boolean)),
-            DataType::Int32 => Ok(Type::Primitive(PrimitiveType::Int)),
+            DataType::Int8 | DataType::Int16 | DataType::Int32 => {
+                Ok(Type::Primitive(PrimitiveType::Int))
+            }
             DataType::Int64 => Ok(Type::Primitive(PrimitiveType::Long)),
             DataType::Float32 => Ok(Type::Primitive(PrimitiveType::Float)),
             DataType::Float64 => Ok(Type::Primitive(PrimitiveType::Double)),
@@ -536,6 +538,10 @@ mod tests {
                 PARQUET_FIELD_ID_META_KEY.to_string(),
                 "2".to_string(),
             )])),
+            Field::new("field3", DataType::Int16, true).with_metadata(HashMap::from([(
+                PARQUET_FIELD_ID_META_KEY.to_string(),
+                "3".to_string(),
+            )])),
         ]);
 
         let struct_type: StructType = (&arrow_schema).try_into().unwrap();
@@ -553,6 +559,13 @@ mod tests {
         assert_eq!(
             struct_type[1].field_type,
             Type::Primitive(PrimitiveType::String)
+        );
+        assert_eq!(struct_type[2].id, 3);
+        assert_eq!(struct_type[2].name, "field3");
+        assert!(!struct_type[2].required);
+        assert_eq!(
+            struct_type[2].field_type,
+            Type::Primitive(PrimitiveType::Int)
         );
     }
 
@@ -844,7 +857,7 @@ mod tests {
 
     #[test]
     fn test_arrow_schema_to_struct_type_unsupported_datatype() {
-        let arrow_schema = ArrowSchema::new(vec![Field::new("field1", DataType::Int8, false)
+        let arrow_schema = ArrowSchema::new(vec![Field::new("field1", DataType::UInt8, false)
             .with_metadata(HashMap::from([(
                 PARQUET_FIELD_ID_META_KEY.to_string(),
                 "1".to_string(),


### PR DESCRIPTION
Analogous to this PR in apache/iceberg-rust: https://github.com/apache/iceberg-rust/pull/787
Analogous to this code in apache/iceberg-python: https://github.com/apache/iceberg-python/blob/547d881948dfe17c92bdde9e5b63a94d095a110d/pyiceberg/io/pyarrow.py#L1081-L1089