### PR TITLE
Configurable access delegation for RestCatalog

### DIFF
--- a/catalogs/iceberg-rest-catalog/src/apis/catalog_api_api.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/catalog_api_api.rs
@@ -782,11 +782,10 @@ pub async fn load_table(
     prefix: Option<&str>,
     namespace: &str,
     table: &str,
-    x_iceberg_access_delegation: Option<&str>,
     snapshots: Option<&str>,
 ) -> Result<models::LoadTableResult, Error<LoadTableError>> {
     let mut headers = HashMap::new();
-    if let Some(param_value) = x_iceberg_access_delegation {
+    if let Some(param_value) = &configuration.x_iceberg_access_delegation {
         headers.insert(
             "X-Iceberg-Access-Delegation".to_owned(),
             param_value.to_string(),

--- a/catalogs/iceberg-rest-catalog/src/apis/configuration.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/configuration.rs
@@ -31,6 +31,8 @@ pub struct Configuration {
     pub api_key: Option<ApiKey>,
     #[builder(setter(into, strip_option), default)]
     pub aws_v4_key: Option<AWSv4Key>,
+    #[builder(setter(into, strip_option), default)]
+    pub x_iceberg_access_delegation: Option<String>,
 }
 
 pub type BasicAuth = (String, Option<String>);
@@ -107,6 +109,7 @@ impl Default for Configuration {
             bearer_access_token: None,
             api_key: None,
             aws_v4_key: None,
+            x_iceberg_access_delegation: None,
         }
     }
 }

--- a/catalogs/iceberg-rest-catalog/src/catalog.rs
+++ b/catalogs/iceberg-rest-catalog/src/catalog.rs
@@ -278,7 +278,6 @@ impl Catalog for RestCatalog {
                         &identifier.namespace().to_string(),
                         identifier.name(),
                         None,
-                        None,
                     )
                     .await
                     .map(|x| x.metadata)
@@ -596,6 +595,7 @@ pub mod tests {
             bearer_access_token: None,
             api_key: None,
             aws_v4_key: None,
+            x_iceberg_access_delegation: None,
         }
     }
     #[tokio::test]

--- a/datafusion_iceberg/tests/integration_trino.rs
+++ b/datafusion_iceberg/tests/integration_trino.rs
@@ -36,6 +36,7 @@ fn configuration(host: &str, port: u16) -> Configuration {
         bearer_access_token: None,
         api_key: None,
         aws_v4_key: None,
+        x_iceberg_access_delegation: None,
     }
 }
 


### PR DESCRIPTION
Move x_iceberg_access_delegation into RestCatalog `Configuration` struct.
This allows a RestCatalog instance to make requests with the `X-Iceberg-Access-Delegation` header.