### PR TITLE
fix: set the correct snapshot number for the replace operation output

### DIFF
--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -510,7 +510,7 @@ impl Operation {
                 let mut snapshot_builder = SnapshotBuilder::default();
                 snapshot_builder
                     .with_snapshot_id(snapshot_id)
-                    .with_sequence_number(0)
+                    .with_sequence_number(sequence_number)
                     .with_schema_id(*schema.schema_id())
                     .with_manifest_list(new_manifest_list_location)
                     .with_summary(Summary {


### PR DESCRIPTION
Instead of the hard-coded `0` use the calculated sequence number (`sequence_number = table_metadata.last_sequence_number + 1`) for the upcoming snapshot's sequence number in the replace operation output.

Besides the spec saying this should be a monotonically increasing number, there are also a number of [validations](https://github.com/apache/iceberg-rust/pull/1167) for this which means this operation would error out with something like `Invalid snapshot with id 8726289446966218055 and sequence number 1 greater than last sequence number 0` otherwise.