### PR TITLE
Fix/commit empty recordbatch stream

### DIFF
--- a/iceberg-rust/src/table/transaction/mod.rs
+++ b/iceberg-rust/src/table/transaction/mod.rs
@@ -344,6 +344,10 @@ impl<'table> TableTransaction<'table> {
             updates.extend(update);
         }
 
+        if updates.is_empty() {
+            return Ok(());
+        }
+
         let new_table = catalog
             .clone()
             .update_table(CommitTable {


### PR DESCRIPTION
Closes #171 

With this PR performing an append operation with empty data and delete files returns an empty Update vector instead of throwing an error. And if there are no updates to be performed, the transaction will also not be committed.