### PR TITLE
feat: bubble up the entire reqwest error

### DIFF
--- a/catalogs/iceberg-rest-catalog/src/error.rs
+++ b/catalogs/iceberg-rest-catalog/src/error.rs
@@ -9,7 +9,7 @@ Error conversion
 impl<T> From<apis::Error<T>> for Error {
     fn from(val: apis::Error<T>) -> Self {
         match val {
-            apis::Error::Reqwest(err) => Error::InvalidFormat(err.to_string()),
+            apis::Error::Reqwest(err) => Error::External(err.into()),
             apis::Error::Serde(err) => Error::JSONSerde(err),
             apis::Error::Io(err) => Error::IO(err),
             apis::Error::ResponseError(ResponseContent {


### PR DESCRIPTION
This PR changes the conversion of the reqwest error, that may occur in the `iceberg-rest-catalog` crate, from `InvalidFormat` to `External` variant.

Besides the fact that `External` seems a more appropriate choice semantically, there's also the matter of obfuscating relevant information buried in the error. The present "downcasting" the reqwest error into a string wrapped up by `InvalidFormat` results in error messages like `error sending request for url (https://lakekeeper-ssl.dev/catalog/v1/568203c4-2034-11f0-894d-bb6b55e6f56f/namespaces) doesn't have the right format`. This is not informative enough, but it also does not allow users of this crate to further troubleshoot the error as only its string representation remains.

In contrast, if wrapped by `External`, one could use a recipe like https://github.com/seanmonstar/reqwest/discussions/2342#discussioncomment-9950047, in order to unravel more information and present it to the user.