### PR TITLE
fix: transparent get_table_metadata_location error

### DIFF
--- a/catalogs/iceberg-s3tables-catalog/src/error.rs
+++ b/catalogs/iceberg-s3tables-catalog/src/error.rs
@@ -4,6 +4,7 @@ use aws_sdk_s3tables::{
     operation::{
         create_namespace::CreateNamespaceError, create_table::CreateTableError,
         delete_table::DeleteTableError, get_table::GetTableError,
+        get_table_metadata_location::GetTableMetadataLocationError,
         list_namespaces::ListNamespacesError, list_tables::ListTablesError,
         update_table_metadata_location::UpdateTableMetadataLocationError,
     },
@@ -26,7 +27,9 @@ pub enum Error {
     #[error(transparent)]
     GetTable(#[from] SdkError<GetTableError, HttpResponse>),
     #[error(transparent)]
-    DeletaTable(#[from] SdkError<DeleteTableError, HttpResponse>),
+    GetTableMetadataLocation(#[from] SdkError<GetTableMetadataLocationError, HttpResponse>),
+    #[error(transparent)]
+    DeleteTable(#[from] SdkError<DeleteTableError, HttpResponse>),
     #[error(transparent)]
     CreateTable(#[from] SdkError<CreateTableError, HttpResponse>),
     #[error(transparent)]

--- a/catalogs/iceberg-s3tables-catalog/src/lib.rs
+++ b/catalogs/iceberg-s3tables-catalog/src/lib.rs
@@ -236,7 +236,7 @@ impl Catalog for S3TablesCatalog {
             .name(identifier.name())
             .send()
             .await
-            .map_err(|_| IcebergError::CatalogNotFound)?;
+            .map_err(Error::from)?;
 
         let metadata_location = table.metadata_location.ok_or(Error::Text(format!(
             "Table {} not found.",


### PR DESCRIPTION
Currently any error whatsoever that occurs during fetching metadata will be displayed as `Entity not found in catalog`, even though it may originate from e.g. connection issues or more likely permission issues.

This PR makes the underlying error transparent by adding another s3tables `GetTableMetadataLocation` error variant, in line with the rest of the client calls.