### PR TITLE
make get_table_metadata_location_error transparent

### DIFF
--- a/catalogs/iceberg-glue-catalog/src/lib.rs
+++ b/catalogs/iceberg-glue-catalog/src/lib.rs
@@ -55,6 +55,7 @@ pub mod schema;
 mod utils;
 
 impl GlueCatalog {
+    #[allow(clippy::result_large_err)]
     pub fn new(
         config: &SdkConfig,
         name: &str,

--- a/catalogs/iceberg-s3tables-catalog/src/error.rs
+++ b/catalogs/iceberg-s3tables-catalog/src/error.rs
@@ -4,6 +4,7 @@ use aws_sdk_s3tables::{
     operation::{
         create_namespace::CreateNamespaceError, create_table::CreateTableError,
         delete_table::DeleteTableError, get_table::GetTableError,
+        get_table_metadata_location::GetTableMetadataLocationError,
         list_namespaces::ListNamespacesError, list_tables::ListTablesError,
         update_table_metadata_location::UpdateTableMetadataLocationError,
     },
@@ -26,7 +27,11 @@ pub enum Error {
     #[error(transparent)]
     GetTable(#[from] SdkError<GetTableError, HttpResponse>),
     #[error(transparent)]
-    DeletaTable(#[from] SdkError<DeleteTableError, HttpResponse>),
+    DeleteTable(#[from] SdkError<DeleteTableError, HttpResponse>),
+    #[error(transparent)]
+    SdkError(#[from] SdkError<GetTableMetadataLocationError, HttpResponse>),
+    #[error(transparent)]
+    GetTableMetadataLocation(#[from] GetTableMetadataLocationError),
     #[error(transparent)]
     CreateTable(#[from] SdkError<CreateTableError, HttpResponse>),
     #[error(transparent)]

--- a/catalogs/iceberg-s3tables-catalog/src/lib.rs
+++ b/catalogs/iceberg-s3tables-catalog/src/lib.rs
@@ -53,6 +53,7 @@ pub struct S3TablesCatalog {
 pub mod error;
 
 impl S3TablesCatalog {
+    #[allow(clippy::result_large_err)]
     pub fn new(
         config: &SdkConfig,
         arn: &str,

--- a/iceberg-rust-spec/src/error.rs
+++ b/iceberg-rust-spec/src/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
     NotSupported(String),
     /// Avro error
     #[error(transparent)]
-    Avro(#[from] apache_avro::Error),
+    Avro(Box<apache_avro::Error>),
     /// Serde json
     #[error(transparent)]
     JSONSerde(#[from] serde_json::Error),
@@ -79,4 +79,10 @@ pub enum Error {
     /// partition spec builder
     #[error(transparent)]
     PartitionSpec(#[from] crate::spec::partition::PartitionSpecBuilderError),
+}
+
+impl From<apache_avro::Error> for Error {
+    fn from(err: apache_avro::Error) -> Self {
+        Error::Avro(Box::new(err))
+    }
 }

--- a/iceberg-rust/src/error.rs
+++ b/iceberg-rust/src/error.rs
@@ -46,7 +46,7 @@ pub enum Error {
     Parquet(#[from] parquet::errors::ParquetError),
     /// Avro error
     #[error(transparent)]
-    Avro(#[from] apache_avro::Error),
+    Avro(Box<apache_avro::Error>),
     /// Thrift error
     #[error(transparent)]
     Thrift(#[from] thrift::Error),
@@ -113,6 +113,12 @@ pub enum Error {
     CreateMaterializedViewBuilder(
         #[from] crate::catalog::create::CreateMaterializedViewBuilderError,
     ),
+}
+
+impl From<apache_avro::Error> for Error {
+    fn from(err: apache_avro::Error) -> Self {
+        Error::Avro(Box::new(err))
+    }
 }
 
 impl From<Error> for ArrowError {

--- a/iceberg-rust/src/sql.rs
+++ b/iceberg-rust/src/sql.rs
@@ -13,7 +13,7 @@ pub fn find_relations(sql: &str) -> Result<Vec<String>, Error> {
     let statements = Parser::parse_sql(&GenericDialect, sql)?;
     let mut visited = Vec::new();
 
-    visit_relations(&statements, |relation| {
+    let _ = visit_relations(&statements, |relation| {
         visited.push(relation.to_string());
         ControlFlow::<()>::Continue(())
     });


### PR DESCRIPTION
Make the underlying S3tables error transparent unless the table cannot be found.