### PR TITLE
feat: vend credentials when loading a tabular

### DIFF
--- a/catalogs/iceberg-rest-catalog/src/catalog.rs
+++ b/catalogs/iceberg-rest-catalog/src/catalog.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::{FutureExt, TryFutureExt};
+use iceberg_rust::object_store::parse::object_store_from_config;
 /**
 Iceberg rest catalog implementation
 */
@@ -609,14 +610,6 @@ impl CatalogList for RestNoPrefixCatalogList {
     }
 }
 
-const CLIENT_REGION: &str = "client.region";
-const AWS_ACCESS_KEY_ID: &str = "s3.access-key-id";
-const AWS_SECRET_ACCESS_KEY: &str = "s3.secret-access-key";
-const AWS_SESSION_TOKEN: &str = "s3.session-token";
-const AWS_REGION: &str = "s3.region";
-const AWS_ENDPOINT: &str = "s3.endpoint";
-const AWS_ALLOW_ANONYMOUS: &str = "s3.allow-anonymous";
-
 fn object_store_from_response(
     response: &models::LoadTableResult,
 ) -> Result<Option<Arc<dyn ObjectStore>>, Error> {
@@ -634,39 +627,7 @@ fn object_store_from_response(
     };
 
     let url = Url::parse(&response.metadata.location)?;
-    match ObjectStoreScheme::parse(&url) {
-        Ok((ObjectStoreScheme::AmazonS3, _path)) => {
-            let access_key_id = config.get(AWS_ACCESS_KEY_ID);
-            let secret_access_key = config.get(AWS_SECRET_ACCESS_KEY);
-            let session_token = config.get(AWS_SESSION_TOKEN);
-            let region = config.get(CLIENT_REGION).or(config.get(AWS_REGION));
-            let endpoint = config.get(AWS_ENDPOINT);
-            let allow_anonymous = config.get(AWS_ALLOW_ANONYMOUS).is_some_and(|s| s == "true");
-            let mut builder = AmazonS3Builder::new().with_url(&response.metadata.location);
-
-            if let Some(region) = region {
-                builder = builder.with_region(region)
-            }
-            if let Some(access_key_id) = access_key_id {
-                builder = builder.with_access_key_id(access_key_id)
-            }
-            if let Some(secret_access_key) = secret_access_key {
-                builder = builder.with_secret_access_key(secret_access_key)
-            }
-            if let Some(session_token) = session_token {
-                builder = builder.with_token(session_token)
-            }
-            if let Some(endpoint) = endpoint {
-                builder = builder.with_endpoint(endpoint)
-            }
-            if allow_anonymous {
-                builder = builder.with_skip_signature(true)
-            }
-
-            Ok(Some(Arc::new(builder.build()?)))
-        }
-        _ => Ok(None),
-    }
+    Ok(Some(object_store_from_config(url, config)?))
 }
 
 #[cfg(test)]

--- a/catalogs/iceberg-rest-catalog/src/catalog.rs
+++ b/catalogs/iceberg-rest-catalog/src/catalog.rs
@@ -1,3 +1,11 @@
+use crate::{
+    apis::{
+        self,
+        catalog_api_api::{self, NamespaceExistsError},
+        configuration::Configuration,
+    },
+    models::{self, StorageCredential},
+};
 use async_trait::async_trait;
 use futures::{FutureExt, TryFutureExt};
 /**
@@ -25,21 +33,13 @@ use iceberg_rust::{
     table::Table,
     view::View,
 };
-use object_store::{aws::AmazonS3Builder, ObjectStore};
+use object_store::{aws::AmazonS3Builder, ObjectStore, ObjectStoreScheme};
 use std::{
     collections::HashMap,
     path::Path,
     sync::{Arc, RwLock},
 };
-
-use crate::{
-    apis::{
-        self,
-        catalog_api_api::{self, NamespaceExistsError},
-        configuration::Configuration,
-    },
-    models::{self, StorageCredential},
-};
+use url::Url;
 
 #[derive(Debug)]
 pub struct RestCatalog {
@@ -287,7 +287,7 @@ impl Catalog for RestCatalog {
                         self.name.as_deref(),
                         &identifier.namespace().to_string(),
                         identifier.name(),
-                        None,
+                        Some("vended-credentials"),
                         None,
                     )
                     .await
@@ -613,43 +613,59 @@ const CLIENT_REGION: &str = "client.region";
 const AWS_ACCESS_KEY_ID: &str = "s3.access-key-id";
 const AWS_SECRET_ACCESS_KEY: &str = "s3.secret-access-key";
 const AWS_SESSION_TOKEN: &str = "s3.session-token";
+const AWS_REGION: &str = "s3.region";
+const AWS_ENDPOINT: &str = "s3.endpoint";
+const AWS_ALLOW_ANONYMOUS: &str = "s3.allow-anonymous";
 
 fn object_store_from_response(
     response: &models::LoadTableResult,
 ) -> Result<Option<Arc<dyn ObjectStore>>, Error> {
     let config = match (&response.storage_credentials, &response.config) {
-        (Some(credentials), _) => Some(&credentials[0].config),
-        (None, Some(config)) => Some(config),
-        (None, None) => None,
+        (Some(credentials), Some(config)) => {
+            // Enrich credentials with other options that might only be found in the config (e.g.
+            // a custom endpoint)
+            let mut options = credentials[0].config.clone();
+            options.extend(config.clone());
+            options
+        }
+        (Some(credentials), None) => credentials[0].config.clone(),
+        (None, Some(config)) => config.clone(),
+        (None, None) => return Ok(None),
     };
 
-    let Some(config) = config else {
-        return Ok(None);
-    };
+    let url = Url::parse(&response.metadata.location)?;
+    match ObjectStoreScheme::parse(&url) {
+        Ok((ObjectStoreScheme::AmazonS3, _path)) => {
+            let access_key_id = config.get(AWS_ACCESS_KEY_ID);
+            let secret_access_key = config.get(AWS_SECRET_ACCESS_KEY);
+            let session_token = config.get(AWS_SESSION_TOKEN);
+            let region = config.get(CLIENT_REGION).or(config.get(AWS_REGION));
+            let endpoint = config.get(AWS_ENDPOINT);
+            let allow_anonymous = config.get(AWS_ALLOW_ANONYMOUS).is_some_and(|s| s == "true");
+            let mut builder = AmazonS3Builder::new().with_url(&response.metadata.location);
 
-    let region = config.get(CLIENT_REGION);
-    if config.contains_key(AWS_ACCESS_KEY_ID) {
-        let access_key_id = config.get(AWS_ACCESS_KEY_ID);
-        let secret_access_key = config.get(AWS_SECRET_ACCESS_KEY);
-        let session_token = config.get(AWS_SESSION_TOKEN);
-        let mut builder = AmazonS3Builder::new();
+            if let Some(region) = region {
+                builder = builder.with_region(region)
+            }
+            if let Some(access_key_id) = access_key_id {
+                builder = builder.with_access_key_id(access_key_id)
+            }
+            if let Some(secret_access_key) = secret_access_key {
+                builder = builder.with_secret_access_key(secret_access_key)
+            }
+            if let Some(session_token) = session_token {
+                builder = builder.with_token(session_token)
+            }
+            if let Some(endpoint) = endpoint {
+                builder = builder.with_endpoint(endpoint)
+            }
+            if allow_anonymous {
+                builder = builder.with_skip_signature(true)
+            }
 
-        if let Some(region) = region {
-            builder = builder.with_region(region)
+            Ok(Some(Arc::new(builder.build()?)))
         }
-        if let Some(access_key_id) = access_key_id {
-            builder = builder.with_access_key_id(access_key_id)
-        }
-        if let Some(secret_access_key) = secret_access_key {
-            builder = builder.with_secret_access_key(secret_access_key)
-        }
-        if let Some(session_token) = session_token {
-            builder = builder.with_token(session_token)
-        }
-
-        Ok(Some(Arc::new(builder.build()?)))
-    } else {
-        Ok(None)
+        _ => Ok(None),
     }
 }
 

--- a/iceberg-rust/src/object_store/mod.rs
+++ b/iceberg-rust/src/object_store/mod.rs
@@ -14,6 +14,7 @@ use object_store::{
 
 use crate::error::Error;
 
+pub mod parse;
 pub mod store;
 
 /// Type for buckets for different cloud providers
@@ -41,14 +42,22 @@ impl Bucket<'_> {
     /// Get the bucket and coud provider from the location string
     pub fn from_path(path: &str) -> Result<Bucket, Error> {
         if path.starts_with("s3://") || path.starts_with("s3a://") {
-            let prefix = if path.starts_with("s3://") { "s3://" } else { "s3a://" };
+            let prefix = if path.starts_with("s3://") {
+                "s3://"
+            } else {
+                "s3a://"
+            };
             path.trim_start_matches(prefix)
                 .split('/')
                 .next()
                 .map(Bucket::S3)
                 .ok_or(Error::NotFound(format!("Bucket in path {path}")))
         } else if path.starts_with("gcs://") || path.starts_with("gs://") {
-            let prefix = if path.starts_with("gcs://") { "gcs://" } else { "gs://" };
+            let prefix = if path.starts_with("gcs://") {
+                "gcs://"
+            } else {
+                "gs://"
+            };
             path.trim_start_matches(prefix)
                 .split('/')
                 .next()

--- a/iceberg-rust/src/object_store/parse.rs
+++ b/iceberg-rust/src/object_store/parse.rs
@@ -1,0 +1,172 @@
+/*! Utils for converting standard Iceberg config formats to equivalent `object_store` options
+*/
+
+use crate::error::Error;
+use object_store::aws::{AmazonS3Builder, AmazonS3ConfigKey};
+use object_store::gcp::{GcpCredential, GoogleCloudStorageBuilder, GoogleConfigKey};
+use object_store::{parse_url_opts, ObjectStore, ObjectStoreScheme, StaticCredentialProvider};
+use std::collections::HashMap;
+use std::sync::Arc;
+use url::Url;
+
+/// AWS configs
+const CLIENT_REGION: &str = "client.region";
+const AWS_ACCESS_KEY_ID: &str = "s3.access-key-id";
+const AWS_SECRET_ACCESS_KEY: &str = "s3.secret-access-key";
+const AWS_SESSION_TOKEN: &str = "s3.session-token";
+const AWS_REGION: &str = "s3.region";
+const AWS_ENDPOINT: &str = "s3.endpoint";
+const AWS_ALLOW_ANONYMOUS: &str = "s3.allow-anonymous";
+
+/// GCP configs
+const GCS_BUCKET: &str = "gcs.bucket";
+const GCS_CREDENTIALS_JSON: &str = "gcs.credentials-json";
+const GCS_TOKEN: &str = "gcs.oauth2.token";
+
+/// Parse the url and Iceberg format of variuos storage options into the equivalent `object_store`
+/// options and build the corresponding `ObjectStore`.
+pub fn object_store_from_config(
+    url: Url,
+    config: HashMap<String, String>,
+) -> Result<Arc<dyn ObjectStore>, Error> {
+    let store = match ObjectStoreScheme::parse(&url).map_err(object_store::Error::from)? {
+        (ObjectStoreScheme::AmazonS3, _) => {
+            let mut builder = AmazonS3Builder::new().with_url(url);
+            for (key, option) in config {
+                let s3_key = match key.as_str() {
+                    AWS_ACCESS_KEY_ID => AmazonS3ConfigKey::AccessKeyId,
+                    AWS_SECRET_ACCESS_KEY => AmazonS3ConfigKey::SecretAccessKey,
+                    AWS_SESSION_TOKEN => AmazonS3ConfigKey::Token,
+                    CLIENT_REGION | AWS_REGION => AmazonS3ConfigKey::Region,
+                    AWS_ENDPOINT => {
+                        if option.starts_with("http://") {
+                            // This is mainly used for testing, e.g. against MinIO
+                            builder = builder.with_allow_http(true);
+                        }
+                        AmazonS3ConfigKey::Endpoint
+                    }
+                    AWS_ALLOW_ANONYMOUS => AmazonS3ConfigKey::SkipSignature,
+                    _ => continue,
+                };
+                builder = builder.with_config(s3_key, option);
+            }
+            Arc::new(builder.build()?) as Arc<dyn ObjectStore>
+        }
+
+        (ObjectStoreScheme::GoogleCloudStorage, _) => {
+            let mut builder = GoogleCloudStorageBuilder::new().with_url(url);
+            for (key, option) in config {
+                let gcs_key = match key.as_str() {
+                    GCS_CREDENTIALS_JSON => GoogleConfigKey::ServiceAccountKey,
+                    GCS_BUCKET => GoogleConfigKey::Bucket,
+                    GCS_TOKEN => {
+                        let credential = GcpCredential { bearer: option };
+                        let credential_provider =
+                            Arc::new(StaticCredentialProvider::new(credential)) as _;
+                        builder = builder.with_credentials(credential_provider);
+                        continue;
+                    }
+                    _ => continue,
+                };
+                builder = builder.with_config(gcs_key, option);
+            }
+            Arc::new(builder.build()?) as Arc<dyn ObjectStore>
+        }
+
+        _ => {
+            let (store, _path) = parse_url_opts(&url, config)?;
+            store.into()
+        }
+    };
+
+    Ok(store)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use url::Url;
+
+    #[test]
+    fn test_s3_config_basic() {
+        let url = Url::parse("s3://test-bucket/path").unwrap();
+        let mut config = HashMap::new();
+        config.insert(AWS_ACCESS_KEY_ID.to_string(), "test-key".to_string());
+        config.insert(AWS_SECRET_ACCESS_KEY.to_string(), "test-secret".to_string());
+        config.insert(AWS_SESSION_TOKEN.to_string(), "test-session".to_string());
+        config.insert(AWS_REGION.to_string(), "us-east-1".to_string());
+
+        let store = object_store_from_config(url, config).unwrap();
+        let store_repr = format!("{:?}", store);
+
+        assert!(store_repr.contains("region: \"us-east-1\""));
+        assert!(store_repr.contains("bucket: \"test-bucket\""));
+        assert!(store_repr.contains("key_id: \"test-key\""));
+        assert!(store_repr.contains("secret_key: \"test-secret\""));
+        assert!(store_repr.contains("token: Some(\"test-session\")"));
+        assert!(store_repr.contains("endpoint: None"));
+        assert!(store_repr.contains("allow_http: Parsed(false)"));
+        assert!(store_repr.contains("skip_signature: false"));
+    }
+
+    #[test]
+    fn test_s3_config_with_http_endpoint() {
+        let url = Url::parse("s3://test-bucket/").unwrap();
+        let mut config = HashMap::new();
+        config.insert(
+            AWS_ENDPOINT.to_string(),
+            "http://localhost:9000".to_string(),
+        );
+        config.insert(AWS_ALLOW_ANONYMOUS.to_string(), "true".to_string());
+
+        let store = object_store_from_config(url, config).unwrap();
+        let store_repr = format!("{:?}", store);
+
+        assert!(store_repr.contains("region: \"us-east-1\""));
+        assert!(store_repr.contains("bucket: \"test-bucket\""));
+        assert!(!store_repr.contains("key_id: "));
+        assert!(!store_repr.contains("secret_key: "));
+        assert!(!store_repr.contains("token: "));
+        assert!(store_repr.contains("endpoint: Some(\"http://localhost:9000\")"));
+        assert!(store_repr.contains("allow_http: Parsed(true)"));
+        assert!(store_repr.contains("skip_signature: true"));
+    }
+
+    #[test]
+    fn test_gcs_config_with_service_account() {
+        let url = Url::parse("gs://test-bucket/").unwrap();
+        let mut config = HashMap::new();
+        config.insert(
+            GCS_CREDENTIALS_JSON.to_string(),
+            json!(
+                {
+                  "disable_oauth": true, "client_email": "", "private_key": "", "private_key_id": ""
+                }
+            )
+            .to_string(),
+        );
+        config.insert(GCS_BUCKET.to_string(), "test-bucket".to_string());
+
+        let store = object_store_from_config(url, config).unwrap();
+        let store_repr = format!("{:?}", store);
+
+        assert!(store_repr.contains("bearer: \"\""));
+        assert!(store_repr.contains("bucket_name: \"test-bucket\""));
+    }
+
+    #[test]
+    fn test_gcs_config_with_oauth_token() {
+        let url = Url::parse("gs://test-bucket/").unwrap();
+        let mut config = HashMap::new();
+        config.insert(GCS_TOKEN.to_string(), "oauth-token-123".to_string());
+        config.insert(GCS_BUCKET.to_string(), "test-bucket".to_string());
+
+        let store = object_store_from_config(url, config).unwrap();
+        let store_repr = format!("{:?}", store);
+
+        assert!(store_repr.contains("bearer: \"oauth-token-123\""));
+        assert!(store_repr.contains("bucket_name: \"test-bucket\""));
+    }
+}


### PR DESCRIPTION
When loading a table/view make sure to pass the vended-credentials header, so that the catalog server returns proper options for accessing the object store. Note that this is also the default in pyiceberg https://github.com/apache/iceberg-python/blob/a67c5592f3243d255519581fedfcc5d93274b9c8/pyiceberg/catalog/rest/__init__.py#L463

In addition parse a couple more options, such as s3.endpoint when creating the object store, as well as some GCP equivalent options.
