### PR TITLE
Add function to obtain partition bounds of snapshot

### DIFF
--- a/catalogs/iceberg-file-catalog/src/lib.rs
+++ b/catalogs/iceberg-file-catalog/src/lib.rs
@@ -716,7 +716,7 @@ pub mod tests {
             .with_config("aws_secret_access_key".parse().unwrap(), "password")
             .with_config(
                 "endpoint".parse().unwrap(),
-                format!("http://{}:{}", localstack_host, localstack_port),
+                format!("http://{localstack_host}:{localstack_port}"),
             )
             .with_config("region".parse().unwrap(), "us-east-1")
             .with_config("allow_http".parse().unwrap(), "true");

--- a/catalogs/iceberg-glue-catalog/src/lib.rs
+++ b/catalogs/iceberg-glue-catalog/src/lib.rs
@@ -1067,7 +1067,7 @@ pub mod tests {
             .with_config("aws_secret_access_key".parse().unwrap(), "password")
             .with_config(
                 "endpoint".parse().unwrap(),
-                format!("http://{}:{}", localstack_host, localstack_port),
+                format!("http://{localstack_host}:{localstack_port}"),
             )
             .with_config("region".parse().unwrap(), "us-east-1")
             .with_config("allow_http".parse().unwrap(), "true");

--- a/catalogs/iceberg-glue-catalog/src/schema.rs
+++ b/catalogs/iceberg-glue-catalog/src/schema.rs
@@ -31,13 +31,11 @@ pub(crate) fn type_to_glue(datatype: &Type) -> Result<String, Error> {
             PrimitiveType::String | PrimitiveType::Uuid => Ok("string".to_owned()),
             PrimitiveType::Binary | PrimitiveType::Fixed(_) => Ok("binary".to_owned()),
             x => Err(Error::InvalidFormat(format!(
-                "Type {} cannot be converted to glue type",
-                x
+                "Type {x} cannot be converted to glue type"
             ))),
         },
         x => Err(Error::InvalidFormat(format!(
-            "Type {} cannot be converted to glue type",
-            x
+            "Type {x} cannot be converted to glue type"
         ))),
     }
 }

--- a/catalogs/iceberg-rest-catalog/src/catalog.rs
+++ b/catalogs/iceberg-rest-catalog/src/catalog.rs
@@ -730,7 +730,7 @@ pub mod tests {
             .with_config("aws_secret_access_key".parse().unwrap(), "password")
             .with_config(
                 "endpoint".parse().unwrap(),
-                format!("http://{}:{}", localstack_host, localstack_port),
+                format!("http://{localstack_host}:{localstack_port}"),
             )
             .with_config("region".parse().unwrap(), "us-east-1")
             .with_config("allow_http".parse().unwrap(), "true");

--- a/catalogs/iceberg-sql-catalog/src/lib.rs
+++ b/catalogs/iceberg-sql-catalog/src/lib.rs
@@ -340,7 +340,7 @@ impl Catalog for SqlCatalog {
             let name = identifier.name().to_string();
             let metadata_location = metadata_location.to_string();
 
-            sqlx::query(&format!("insert into iceberg_tables (catalog_name, table_namespace, table_name, metadata_location) values ('{}', '{}', '{}', '{}');",catalog_name,namespace,name, metadata_location)).execute(&self.pool).await.map_err(Error::from)?;
+            sqlx::query(&format!("insert into iceberg_tables (catalog_name, table_namespace, table_name, metadata_location) values ('{catalog_name}', '{namespace}', '{name}', '{metadata_location}');")).execute(&self.pool).await.map_err(Error::from)?;
         }
         self.cache.write().unwrap().insert(
             identifier.clone(),
@@ -380,7 +380,7 @@ impl Catalog for SqlCatalog {
             let name = identifier.name().to_string();
             let metadata_location = metadata_location.to_string();
 
-            sqlx::query(&format!("insert into iceberg_tables (catalog_name, table_namespace, table_name, metadata_location) values ('{}', '{}', '{}', '{}');",catalog_name,namespace,name, metadata_location)).execute(&self.pool).await.map_err(Error::from)?;
+            sqlx::query(&format!("insert into iceberg_tables (catalog_name, table_namespace, table_name, metadata_location) values ('{catalog_name}', '{namespace}', '{name}', '{metadata_location}');")).execute(&self.pool).await.map_err(Error::from)?;
         }
         self.cache.write().unwrap().insert(
             identifier.clone(),
@@ -423,14 +423,14 @@ impl Catalog for SqlCatalog {
             let name = identifier.name().to_string();
             let metadata_location = metadata_location.to_string();
 
-            sqlx::query(&format!("insert into iceberg_tables (catalog_name, table_namespace, table_name, metadata_location) values ('{}', '{}', '{}', '{}');",catalog_name,namespace,name, metadata_location)).execute(&mut *transaction).await.map_err(Error::from)?;
+            sqlx::query(&format!("insert into iceberg_tables (catalog_name, table_namespace, table_name, metadata_location) values ('{catalog_name}', '{namespace}', '{name}', '{metadata_location}');")).execute(&mut *transaction).await.map_err(Error::from)?;
 
             let table_catalog_name = self.name.clone();
             let table_namespace = table_identifier.namespace().to_string();
             let table_name = table_identifier.name().to_string();
             let table_metadata_location = table_metadata_location.to_string();
 
-            sqlx::query(&format!("insert into iceberg_tables (catalog_name, table_namespace, table_name, metadata_location) values ('{}', '{}', '{}', '{}');",table_catalog_name,table_namespace,table_name, table_metadata_location)).execute(&mut *transaction).await.map_err(Error::from)?;
+            sqlx::query(&format!("insert into iceberg_tables (catalog_name, table_namespace, table_name, metadata_location) values ('{table_catalog_name}', '{table_namespace}', '{table_name}', '{table_metadata_location}');")).execute(&mut *transaction).await.map_err(Error::from)?;
 
             transaction.commit().await.map_err(Error::from)?;
         }
@@ -483,7 +483,7 @@ impl Catalog for SqlCatalog {
         let metadata_file_location = metadata_location.to_string();
         let previous_metadata_file_location = previous_metadata_location.to_string();
 
-        sqlx::query(&format!("update iceberg_tables set metadata_location = '{}', previous_metadata_location = '{}' where catalog_name = '{}' and table_namespace = '{}' and table_name = '{}' and metadata_location = '{}';", metadata_file_location, previous_metadata_file_location,catalog_name,namespace,name, previous_metadata_file_location)).execute(&self.pool).await.map_err(Error::from)?;
+        sqlx::query(&format!("update iceberg_tables set metadata_location = '{metadata_file_location}', previous_metadata_location = '{previous_metadata_file_location}' where catalog_name = '{catalog_name}' and table_namespace = '{namespace}' and table_name = '{name}' and metadata_location = '{previous_metadata_file_location}';")).execute(&self.pool).await.map_err(Error::from)?;
 
         self.cache.write().unwrap().insert(
             identifier.clone(),
@@ -541,7 +541,7 @@ impl Catalog for SqlCatalog {
         let metadata_file_location = metadata_location.to_string();
         let previous_metadata_file_location = previous_metadata_location.to_string();
 
-        sqlx::query(&format!("update iceberg_tables set metadata_location = '{}', previous_metadata_location = '{}' where catalog_name = '{}' and table_namespace = '{}' and table_name = '{}' and metadata_location = '{}';", metadata_file_location, previous_metadata_file_location,catalog_name,namespace,name,previous_metadata_file_location)).execute(&self.pool).await.map_err(Error::from)?;
+        sqlx::query(&format!("update iceberg_tables set metadata_location = '{metadata_file_location}', previous_metadata_location = '{previous_metadata_file_location}' where catalog_name = '{catalog_name}' and table_namespace = '{namespace}' and table_name = '{name}' and metadata_location = '{previous_metadata_file_location}';")).execute(&self.pool).await.map_err(Error::from)?;
         self.cache.write().unwrap().insert(
             identifier.clone(),
             (metadata_location.clone(), metadata.clone()),
@@ -597,7 +597,7 @@ impl Catalog for SqlCatalog {
         let metadata_file_location = metadata_location.to_string();
         let previous_metadata_file_location = previous_metadata_location.to_string();
 
-        sqlx::query(&format!("update iceberg_tables set metadata_location = '{}', previous_metadata_location = '{}' where catalog_name = '{}' and table_namespace = '{}' and table_name = '{}' and metadata_location = '{}';", metadata_file_location, previous_metadata_file_location,catalog_name,namespace,name, previous_metadata_file_location)).execute(&self.pool).await.map_err(Error::from)?;
+        sqlx::query(&format!("update iceberg_tables set metadata_location = '{metadata_file_location}', previous_metadata_location = '{previous_metadata_file_location}' where catalog_name = '{catalog_name}' and table_namespace = '{namespace}' and table_name = '{name}' and metadata_location = '{previous_metadata_file_location}';")).execute(&self.pool).await.map_err(Error::from)?;
         self.cache.write().unwrap().insert(
             identifier.clone(),
             (metadata_location.clone(), metadata.clone()),
@@ -633,7 +633,7 @@ impl Catalog for SqlCatalog {
             let name = identifier.name().to_string();
             let metadata_location = metadata_location.to_string();
 
-            sqlx::query(&format!("insert into iceberg_tables (catalog_name, table_namespace, table_name, metadata_location) values ('{}', '{}', '{}', '{}');",catalog_name,namespace,name, metadata_location)).execute(&self.pool).await.map_err(Error::from)?;
+            sqlx::query(&format!("insert into iceberg_tables (catalog_name, table_namespace, table_name, metadata_location) values ('{catalog_name}', '{namespace}', '{name}', '{metadata_location}');")).execute(&self.pool).await.map_err(Error::from)?;
         }
         self.cache.write().unwrap().insert(
             identifier.clone(),
@@ -810,7 +810,7 @@ pub mod tests {
             .with_config("aws_secret_access_key".parse().unwrap(), "password")
             .with_config(
                 "endpoint".parse().unwrap(),
-                format!("http://{}:{}", localstack_host, localstack_port),
+                format!("http://{localstack_host}:{localstack_port}"),
             )
             .with_config("region".parse().unwrap(), "us-east-1")
             .with_config("allow_http".parse().unwrap(), "true");
@@ -818,8 +818,7 @@ pub mod tests {
         let iceberg_catalog = Arc::new(
             SqlCatalog::new(
                 &format!(
-                    "postgres://postgres:postgres@{}:{}/postgres",
-                    postgres_host, postgres_port
+                    "postgres://postgres:postgres@{postgres_host}:{postgres_port}/postgres"
                 ),
                 "warehouse",
                 object_store,

--- a/catalogs/iceberg-sql-catalog/src/lib.rs
+++ b/catalogs/iceberg-sql-catalog/src/lib.rs
@@ -817,9 +817,7 @@ pub mod tests {
 
         let iceberg_catalog = Arc::new(
             SqlCatalog::new(
-                &format!(
-                    "postgres://postgres:postgres@{postgres_host}:{postgres_port}/postgres"
-                ),
+                &format!("postgres://postgres:postgres@{postgres_host}:{postgres_port}/postgres"),
                 "warehouse",
                 object_store,
             )

--- a/datafusion_iceberg/src/statistics.rs
+++ b/datafusion_iceberg/src/statistics.rs
@@ -165,7 +165,7 @@ fn convert_value_to_scalar_value(value: Value) -> Result<ScalarValue, Error> {
         )),
         x => Err(Error::Conversion(
             "Iceberg value".to_string(),
-            format!("{:?}", x),
+            format!("{x:?}"),
         )),
     }
 }

--- a/datafusion_iceberg/src/table.rs
+++ b/datafusion_iceberg/src/table.rs
@@ -318,7 +318,7 @@ fn fake_object_store_url(table_location_url: &str) -> Option<ObjectStoreUrl> {
         u.path()
             .as_bytes()
             .iter()
-            .map(|b| format!("{:02x}", b))
+            .map(|b| format!("{b:02x}"))
             .collect::<Vec<_>>()
             .join("")
     )))

--- a/datafusion_iceberg/tests/empty_insert.rs
+++ b/datafusion_iceberg/tests/empty_insert.rs
@@ -48,7 +48,7 @@ pub async fn test_empty_insert() {
         .with_config("aws_secret_access_key".parse().unwrap(), "password")
         .with_config(
             "endpoint".parse().unwrap(),
-            format!("http://{}:{}", localstack_host, localstack_port),
+            format!("http://{localstack_host}:{localstack_port}"),
         )
         .with_config("region".parse().unwrap(), "us-east-1")
         .with_config("allow_http".parse().unwrap(), "true");

--- a/datafusion_iceberg/tests/integration_trino.rs
+++ b/datafusion_iceberg/tests/integration_trino.rs
@@ -29,7 +29,7 @@ use tokio::time::sleep;
 
 fn configuration(host: &str, port: u16) -> Configuration {
     Configuration {
-        base_path: format!("http://{}:{}", host, port),
+        base_path: format!("http://{host}:{port}"),
         user_agent: None,
         client: reqwest::Client::new(),
         basic_auth: None,
@@ -63,7 +63,7 @@ async fn wait_for_worker(trino_container: &ContainerAsync<GenericImage>, timeout
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
-    panic!("Trino still not queryable after {:?}", timeout);
+    panic!("Trino still not queryable after {timeout:?}");
 }
 
 #[tokio::test]
@@ -130,8 +130,7 @@ async fn integration_trino_rest() {
     writeln!(tmp_file, "iceberg.catalog.type=rest").unwrap();
     writeln!(
         tmp_file,
-        "iceberg.rest-catalog.uri=http://{}:{}",
-        docker_host, rest_port
+        "iceberg.rest-catalog.uri=http://{docker_host}:{rest_port}"
     )
     .unwrap();
     writeln!(tmp_file, "iceberg.rest-catalog.warehouse=s3://warehouse/").unwrap();
@@ -139,8 +138,7 @@ async fn integration_trino_rest() {
     writeln!(tmp_file, "fs.native-s3.enabled=true").unwrap();
     writeln!(
         tmp_file,
-        "s3.endpoint=http://{}:{}",
-        docker_host, localstack_port
+        "s3.endpoint=http://{docker_host}:{localstack_port}"
     )
     .unwrap();
     writeln!(tmp_file, "s3.path-style-access=true").unwrap();
@@ -179,7 +177,7 @@ async fn integration_trino_rest() {
                 "iceberg",
                 "--file",
                 "/tmp/trino.sql",
-                &format!("http://{}:{}", docker_host, trino_port),
+                &format!("http://{docker_host}:{trino_port}"),
             ])
             .with_cmd_ready_condition(CmdWaitFor::exit_code(0)),
         )
@@ -191,7 +189,7 @@ async fn integration_trino_rest() {
         .with_config("aws_secret_access_key".parse().unwrap(), "password")
         .with_config(
             "endpoint".parse().unwrap(),
-            format!("http://{}:{}", localstack_host, localstack_port),
+            format!("http://{localstack_host}:{localstack_port}"),
         )
         .with_config("region".parse().unwrap(), "us-east-1")
         .with_config("allow_http".parse().unwrap(), "true");
@@ -294,7 +292,7 @@ async fn integration_trino_rest() {
                 "SELECT sum(amount) FROM iceberg.test.test_orders;",
                 "--output-format",
                 "NULL",
-                &format!("http://{}:{}", docker_host, trino_port),
+                &format!("http://{docker_host}:{trino_port}"),
             ])
             .with_cmd_ready_condition(CmdWaitFor::exit_code(0)),
         )

--- a/iceberg-rust-spec/src/arrow/schema.rs
+++ b/iceberg-rust-spec/src/arrow/schema.rs
@@ -172,8 +172,7 @@ impl TryFrom<&DataType> for Type {
                 element: Box::new(field.data_type().try_into()?),
             })),
             x => Err(Error::NotSupported(format!(
-                "Arrow datatype {} is not supported.",
-                x
+                "Arrow datatype {x} is not supported."
             ))),
         }
     }

--- a/iceberg-rust-spec/src/spec/identifier.rs
+++ b/iceberg-rust-spec/src/spec/identifier.rs
@@ -34,13 +34,11 @@ impl Identifier {
     pub fn try_new(names: &[String], default_namespace: Option<&[String]>) -> Result<Self, Error> {
         let mut parts = names.iter().rev();
         let table_name = parts.next().ok_or(Error::InvalidFormat(format!(
-            "Identifier {:?} is empty",
-            names
+            "Identifier {names:?} is empty"
         )))?;
         if table_name.is_empty() {
             return Err(Error::InvalidFormat(format!(
-                "Table name {:?} is empty",
-                table_name
+                "Table name {table_name:?} is empty"
             )));
         }
         let namespace: Vec<String> = parts.rev().map(ToOwned::to_owned).collect();
@@ -133,7 +131,7 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(&format!("{}", identifier), "level1.level2.table");
+        assert_eq!(&format!("{identifier}"), "level1.level2.table");
     }
     #[test]
     #[should_panic]
@@ -152,6 +150,6 @@ mod tests {
     #[test]
     fn test_parse() {
         let identifier = Identifier::parse("level1.level2.table", None).unwrap();
-        assert_eq!(&format!("{}", identifier), "level1.level2.table");
+        assert_eq!(&format!("{identifier}"), "level1.level2.table");
     }
 }

--- a/iceberg-rust-spec/src/spec/manifest.rs
+++ b/iceberg-rust-spec/src/spec/manifest.rs
@@ -496,7 +496,7 @@ impl AvroMap<ByteBuf> {
                                 .get(k as usize)
                                 .ok_or(Error::ColumnNotInSchema(
                                     k.to_string(),
-                                    format!("{:?}", schema),
+                                    format!("{schema:?}"),
                                 ))?
                                 .field_type,
                         )?,

--- a/iceberg-rust-spec/src/spec/namespace.rs
+++ b/iceberg-rust-spec/src/spec/namespace.rs
@@ -36,8 +36,7 @@ impl Namespace {
             url::form_urlencoded::parse(namespace.as_bytes())
                 .next()
                 .ok_or(Error::InvalidFormat(format!(
-                    "Namespace {} is empty",
-                    namespace
+                    "Namespace {namespace} is empty"
                 )))?
                 .0
                 .split('\u{1F}')
@@ -78,7 +77,7 @@ mod tests {
             "level3".to_string(),
         ])
         .unwrap();
-        assert_eq!(&format!("{}", namespace), "level1.level2.level3");
+        assert_eq!(&format!("{namespace}"), "level1.level2.level3");
     }
     #[test]
     #[should_panic]

--- a/iceberg-rust-spec/src/spec/partition.rs
+++ b/iceberg-rust-spec/src/spec/partition.rs
@@ -133,8 +133,8 @@ impl Display for Transform {
             Transform::Month => write!(f, "month"),
             Transform::Day => write!(f, "day"),
             Transform::Hour => write!(f, "hour"),
-            Transform::Bucket(i) => write!(f, "bucket[{}]", i),
-            Transform::Truncate(i) => write!(f, "truncate[{}]", i),
+            Transform::Bucket(i) => write!(f, "bucket[{i}]"),
+            Transform::Truncate(i) => write!(f, "truncate[{i}]"),
             Transform::Void => write!(f, "void"),
         }
     }

--- a/iceberg-rust-spec/src/spec/types.rs
+++ b/iceberg-rust-spec/src/spec/types.rs
@@ -45,7 +45,7 @@ pub enum Type {
 impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Type::Primitive(primitive) => write!(f, "{}", primitive),
+            Type::Primitive(primitive) => write!(f, "{primitive}"),
             Type::Struct(_) => write!(f, "struct"),
             Type::List(_) => write!(f, "list"),
             Type::Map(_) => write!(f, "map"),

--- a/iceberg-rust-spec/src/spec/values.rs
+++ b/iceberg-rust-spec/src/spec/values.rs
@@ -135,20 +135,20 @@ impl From<Value> for ByteBuf {
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Value::Boolean(b) => write!(f, "{}", b),
-            Value::Int(i) => write!(f, "{}", i),
-            Value::LongInt(l) => write!(f, "{}", l),
-            Value::Float(fl) => write!(f, "{}", fl),
-            Value::Double(d) => write!(f, "{}", d),
-            Value::Date(d) => write!(f, "{}", d),
-            Value::Time(t) => write!(f, "{}", t),
-            Value::Timestamp(ts) => write!(f, "{}", ts),
-            Value::TimestampTZ(ts) => write!(f, "{}", ts),
-            Value::String(s) => write!(f, "{}", s),
-            Value::UUID(u) => write!(f, "{}", u),
-            Value::Fixed(size, data) => write!(f, "{:?} ({} bytes)", data, size),
+            Value::Boolean(b) => write!(f, "{b}"),
+            Value::Int(i) => write!(f, "{i}"),
+            Value::LongInt(l) => write!(f, "{l}"),
+            Value::Float(fl) => write!(f, "{fl}"),
+            Value::Double(d) => write!(f, "{d}"),
+            Value::Date(d) => write!(f, "{d}"),
+            Value::Time(t) => write!(f, "{t}"),
+            Value::Timestamp(ts) => write!(f, "{ts}"),
+            Value::TimestampTZ(ts) => write!(f, "{ts}"),
+            Value::String(s) => write!(f, "{s}"),
+            Value::UUID(u) => write!(f, "{u}"),
+            Value::Fixed(size, data) => write!(f, "{data:?} ({size} bytes)"),
             Value::Binary(data) => write!(f, "{:?} ({} bytes)", data, data.len()),
-            Value::Decimal(d) => write!(f, "{}", d),
+            Value::Decimal(d) => write!(f, "{d}"),
             _ => panic!("Printing of compound types is not supported"),
         }
     }
@@ -782,13 +782,13 @@ impl From<&Value> for JsonValue {
             Value::UUID(val) => JsonValue::String(val.to_string()),
             Value::Fixed(_, val) => {
                 JsonValue::String(val.iter().fold(String::new(), |mut acc, x| {
-                    acc.push_str(&format!("{:x}", x));
+                    acc.push_str(&format!("{x:x}"));
                     acc
                 }))
             }
             Value::Binary(val) => {
                 JsonValue::String(val.iter().fold(String::new(), |mut acc, x| {
-                    acc.push_str(&format!("{:x}", x));
+                    acc.push_str(&format!("{x:x}"));
                     acc
                 }))
             }

--- a/iceberg-rust/src/arrow/write.rs
+++ b/iceberg-rust/src/arrow/write.rs
@@ -472,7 +472,7 @@ async fn create_arrow_writer(
         rand[0..3]
             .iter()
             .fold(String::with_capacity(8), |mut acc, x| {
-                write!(&mut acc, "{:x}", x).unwrap();
+                write!(&mut acc, "{x:x}").unwrap();
                 acc
             })
             + "/"

--- a/iceberg-rust/src/object_store/mod.rs
+++ b/iceberg-rust/src/object_store/mod.rs
@@ -31,8 +31,8 @@ pub enum Bucket<'s> {
 impl Display for Bucket<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Bucket::S3(s) => write!(f, "s3://{}", s),
-            Bucket::GCS(s) => write!(f, "gs://{}", s),
+            Bucket::S3(s) => write!(f, "s3://{s}"),
+            Bucket::GCS(s) => write!(f, "gs://{s}"),
             Bucket::Local => write!(f, ""),
         }
     }

--- a/iceberg-rust/src/object_store/parse.rs
+++ b/iceberg-rust/src/object_store/parse.rs
@@ -99,7 +99,7 @@ mod tests {
         config.insert(AWS_REGION.to_string(), "us-east-1".to_string());
 
         let store = object_store_from_config(url, config).unwrap();
-        let store_repr = format!("{:?}", store);
+        let store_repr = format!("{store:?}");
 
         assert!(store_repr.contains("region: \"us-east-1\""));
         assert!(store_repr.contains("bucket: \"test-bucket\""));
@@ -122,7 +122,7 @@ mod tests {
         config.insert(AWS_ALLOW_ANONYMOUS.to_string(), "true".to_string());
 
         let store = object_store_from_config(url, config).unwrap();
-        let store_repr = format!("{:?}", store);
+        let store_repr = format!("{store:?}");
 
         assert!(store_repr.contains("region: \"us-east-1\""));
         assert!(store_repr.contains("bucket: \"test-bucket\""));
@@ -150,7 +150,7 @@ mod tests {
         config.insert(GCS_BUCKET.to_string(), "test-bucket".to_string());
 
         let store = object_store_from_config(url, config).unwrap();
-        let store_repr = format!("{:?}", store);
+        let store_repr = format!("{store:?}");
 
         assert!(store_repr.contains("bearer: \"\""));
         assert!(store_repr.contains("bucket_name: \"test-bucket\""));
@@ -164,7 +164,7 @@ mod tests {
         config.insert(GCS_BUCKET.to_string(), "test-bucket".to_string());
 
         let store = object_store_from_config(url, config).unwrap();
-        let store_repr = format!("{:?}", store);
+        let store_repr = format!("{store:?}");
 
         assert!(store_repr.contains("bearer: \"oauth-token-123\""));
         assert!(store_repr.contains("bucket_name: \"test-bucket\""));

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -608,8 +608,7 @@ pub(crate) fn new_manifest_location(
     i: usize,
 ) -> String {
     format!(
-        "{}/metadata/{}-m{}.avro",
-        table_metadata_location, commit_uuid, i
+        "{table_metadata_location}/metadata/{commit_uuid}-m{i}.avro"
     )
 }
 
@@ -620,8 +619,7 @@ pub(crate) fn new_manifest_list_location(
     commit_uuid: &str,
 ) -> String {
     format!(
-        "{}/metadata/snap-{}-{}-{}.avro",
-        table_metadata_location, snapshot_id, attempt, commit_uuid
+        "{table_metadata_location}/metadata/snap-{snapshot_id}-{attempt}-{commit_uuid}.avro"
     )
 }
 

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -607,9 +607,7 @@ pub(crate) fn new_manifest_location(
     commit_uuid: &str,
     i: usize,
 ) -> String {
-    format!(
-        "{table_metadata_location}/metadata/{commit_uuid}-m{i}.avro"
-    )
+    format!("{table_metadata_location}/metadata/{commit_uuid}-m{i}.avro")
 }
 
 pub(crate) fn new_manifest_list_location(
@@ -618,9 +616,7 @@ pub(crate) fn new_manifest_list_location(
     attempt: i64,
     commit_uuid: &str,
 ) -> String {
-    format!(
-        "{table_metadata_location}/metadata/snap-{snapshot_id}-{attempt}-{commit_uuid}.avro"
-    )
+    format!("{table_metadata_location}/metadata/snap-{snapshot_id}-{attempt}-{commit_uuid}.avro")
 }
 
 /// To achieve fast lookups of the datafiles, the manifest tree should be somewhat balanced, meaning that manifest files should contain a similar number of datafiles.

--- a/iceberg-rust/src/util/mod.rs
+++ b/iceberg-rust/src/util/mod.rs
@@ -11,7 +11,7 @@ use crate::error::Error;
 type Vec4<T> = SmallVec<[T; 4]>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct Rectangle {
+pub struct Rectangle {
     pub min: Vec4<Value>,
     pub max: Vec4<Value>,
 }

--- a/iceberg-rust/tests/overwrite_test.rs
+++ b/iceberg-rust/tests/overwrite_test.rs
@@ -280,7 +280,7 @@ async fn test_table_transaction_overwrite() {
                 _ => {}
             }
 
-            println!("  Row: id={}, region={}, value={}", id, region, value);
+            println!("  Row: id={id}, region={region}, value={value}");
         }
     }
 
@@ -392,7 +392,7 @@ async fn create_files_to_overwrite_for_partition(
     let _current_snapshot = table
         .metadata()
         .current_snapshot(None)
-        .map_err(|e| Error::InvalidFormat(format!("Failed to get current snapshot: {:?}", e)))?
+        .map_err(|e| Error::InvalidFormat(format!("Failed to get current snapshot: {e:?}")))?
         .ok_or(Error::InvalidFormat("No current snapshot".to_owned()))?;
 
     // Read the manifest list from the current snapshot


### PR DESCRIPTION
## Summary
- Add new `snapshot_partition_bounds` function to compute overall partition bounds for all data files in a snapshot
- The function reads the manifest list and computes a bounding rectangle that encompasses all partition values
- Useful for understanding data distribution and query optimization

## Changes
- Added `snapshot_partition_bounds` function in `iceberg-rust/src/table/manifest_list.rs`
- Function iterates through manifest entries and expands bounds for each partition summary
- Returns `Option<Rectangle>` containing the combined bounding rectangle or None if no partitions found
- Includes comprehensive documentation with usage examples

🤖 Generated with [Claude Code](https://claude.ai/code)