### PR TITLE
Extend catalog mirror with schema management

### DIFF
--- a/catalogs/iceberg-sql-catalog/src/lib.rs
+++ b/catalogs/iceberg-sql-catalog/src/lib.rs
@@ -168,7 +168,7 @@ impl Catalog for SqlCatalog {
         // If no properties were provided, still create an entry to mark the namespace as existing
         if properties.is_empty() {
             sqlx::query(&format!(
-                "insert into iceberg_namespace_properties (catalog_name, namespace, property_key, property_value) values ('{catalog_name}', '{namespace_str}', null, null);"
+                "insert into iceberg_namespace_properties (catalog_name, namespace, property_key, property_value) values ('{catalog_name}', '{namespace_str}', 'exists', 'true');"
             ))
             .execute(&self.pool)
             .await
@@ -862,6 +862,19 @@ pub mod tests {
         let ctx = SessionContext::new_with_state(state);
 
         ctx.register_catalog("warehouse", catalog);
+
+        let sql = &"CREATE SCHEMA warehouse.tpch;".to_string();
+
+        let plan = ctx.state().create_logical_plan(sql).await.unwrap();
+
+        let transformed = plan.transform(iceberg_transform).data().unwrap();
+
+        ctx.execute_logical_plan(transformed)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .expect("Failed to execute query plan.");
 
         let sql = "CREATE EXTERNAL TABLE lineitem ( 
     L_ORDERKEY BIGINT NOT NULL, 

--- a/catalogs/iceberg-sql-catalog/src/lib.rs
+++ b/catalogs/iceberg-sql-catalog/src/lib.rs
@@ -148,10 +148,34 @@ impl Catalog for SqlCatalog {
     /// Create a namespace in the catalog
     async fn create_namespace(
         &self,
-        _namespace: &Namespace,
-        _properties: Option<HashMap<String, String>>,
+        namespace: &Namespace,
+        properties: Option<HashMap<String, String>>,
     ) -> Result<HashMap<String, String>, IcebergError> {
-        todo!()
+        let catalog_name = self.name.clone();
+        let namespace_str = namespace.to_string();
+        let properties = properties.unwrap_or_default();
+
+        // Insert namespace properties into the database
+        for (key, value) in &properties {
+            sqlx::query(&format!(
+                "insert into iceberg_namespace_properties (catalog_name, namespace, property_key, property_value) values ('{catalog_name}', '{namespace_str}', '{key}', '{value}');"
+            ))
+            .execute(&self.pool)
+            .await
+            .map_err(Error::from)?;
+        }
+
+        // If no properties were provided, still create an entry to mark the namespace as existing
+        if properties.is_empty() {
+            sqlx::query(&format!(
+                "insert into iceberg_namespace_properties (catalog_name, namespace, property_key, property_value) values ('{catalog_name}', '{namespace_str}', null, null);"
+            ))
+            .execute(&self.pool)
+            .await
+            .map_err(Error::from)?;
+        }
+
+        Ok(properties)
     }
     /// Drop a namespace in the catalog
     async fn drop_namespace(&self, _namespace: &Namespace) -> Result<(), IcebergError> {
@@ -201,8 +225,7 @@ impl Catalog for SqlCatalog {
 
         let rows = {
             sqlx::query(&format!(
-                "select distinct table_namespace from iceberg_tables where catalog_name = '{}';",
-                &name
+                "select distinct namespace from iceberg_namespace_properties where catalog_name = '{name}';",
             ))
             .fetch_all(&self.pool)
             .await

--- a/datafusion_iceberg/src/catalog/catalog.rs
+++ b/datafusion_iceberg/src/catalog/catalog.rs
@@ -57,9 +57,14 @@ impl CatalogProvider for IcebergCatalog {
 
     fn register_schema(
         &self,
-        _name: &str,
+        name: &str,
         _schema: Arc<dyn SchemaProvider>,
     ) -> Result<Option<Arc<dyn SchemaProvider>>> {
-        unimplemented!()
+        let old_namespace = self.catalog.register_schema(name)?;
+        if old_namespace.is_some() {
+            Ok(self.schema(name))
+        } else {
+            Ok(None)
+        }
     }
 }

--- a/datafusion_iceberg/src/catalog/catalog.rs
+++ b/datafusion_iceberg/src/catalog/catalog.rs
@@ -70,4 +70,16 @@ impl CatalogProvider for IcebergCatalog {
             Ok(None)
         }
     }
+
+    fn deregister_schema(
+        &self,
+        name: &str,
+        _cascade: bool,
+    ) -> Result<Option<Arc<dyn SchemaProvider>>> {
+        if self.catalog.deregister_schema(name)?.is_some() {
+            Ok(self.schema(name))
+        } else {
+            Ok(None)
+        }
+    }
 }

--- a/datafusion_iceberg/src/catalog/catalog.rs
+++ b/datafusion_iceberg/src/catalog/catalog.rs
@@ -43,6 +43,9 @@ impl CatalogProvider for IcebergCatalog {
         }
     }
     fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        if !self.catalog.schema_exists(name) {
+            return None;
+        }
         Some(Arc::new(IcebergSchema::new(
             Namespace::try_new(
                 &name

--- a/datafusion_iceberg/src/catalog/catalog.rs
+++ b/datafusion_iceberg/src/catalog/catalog.rs
@@ -29,6 +29,10 @@ impl IcebergCatalog {
     pub fn catalog(&self) -> Arc<dyn Catalog> {
         self.catalog.catalog()
     }
+
+    pub fn mirror(&self) -> Arc<Mirror> {
+        self.catalog.clone()
+    }
 }
 
 impl CatalogProvider for IcebergCatalog {

--- a/datafusion_iceberg/src/catalog/catalog_list.rs
+++ b/datafusion_iceberg/src/catalog/catalog_list.rs
@@ -50,7 +50,10 @@ impl CatalogProviderList for IcebergCatalogList {
     fn catalog(&self, name: &str) -> Option<Arc<dyn CatalogProvider>> {
         self.catalogs.get(name).as_deref().cloned().or_else(|| {
             self.catalog_list.catalog(name).map(|catalog| {
-                Arc::new(IcebergCatalog::new_sync(catalog, None)) as Arc<dyn CatalogProvider>
+                let iceberg_catalog = Arc::new(IcebergCatalog::new_sync(catalog, None));
+                self.catalogs
+                    .insert(name.to_owned(), iceberg_catalog.clone());
+                iceberg_catalog as Arc<dyn CatalogProvider>
             })
         })
     }

--- a/datafusion_iceberg/src/catalog/mirror.rs
+++ b/datafusion_iceberg/src/catalog/mirror.rs
@@ -184,6 +184,12 @@ impl Mirror {
         self.storage.contains_key(&identifier.to_string())
     }
 
+    pub fn schema_exists(&self, name: &str) -> bool {
+        self.storage.get(name).map_or(false, |node| {
+            matches!(node.value(), Node::Namespace(_))
+        })
+    }
+
     pub fn catalog(&self) -> Arc<dyn Catalog> {
         self.catalog.clone()
     }

--- a/datafusion_iceberg/src/catalog/mirror.rs
+++ b/datafusion_iceberg/src/catalog/mirror.rs
@@ -217,4 +217,14 @@ impl Mirror {
             .insert(namespace.to_string(), Node::Namespace(HashSet::new()));
         Ok(old_value)
     }
+
+    pub fn deregister_schema(&self, name: &str) -> Result<Option<NamespaceNode>, DataFusionError> {
+        match self.storage.remove(name) {
+            Some((_, Node::Namespace(namespace))) => Ok(Some(namespace)),
+            None => Ok(None),
+            _ => Err(DataFusionError::from(Error::from(
+                IcebergError::InvalidFormat("Schema to drop".to_owned()),
+            ))),
+        }
+    }
 }

--- a/datafusion_iceberg/src/catalog/mirror.rs
+++ b/datafusion_iceberg/src/catalog/mirror.rs
@@ -1,7 +1,6 @@
 use dashmap::DashMap;
 use datafusion::{datasource::TableProvider, error::DataFusionError};
 use std::{collections::HashSet, sync::Arc};
-use tokio::runtime::Handle;
 
 use iceberg_rust::spec::view_metadata::REF_PREFIX;
 use iceberg_rust::{

--- a/datafusion_iceberg/src/catalog/mirror.rs
+++ b/datafusion_iceberg/src/catalog/mirror.rs
@@ -183,13 +183,13 @@ impl Mirror {
     pub fn table_exists(&self, identifier: Identifier) -> bool {
         self.storage
             .get(&identifier.to_string())
-            .map_or(false, |node| matches!(node.value(), Node::Relation(_)))
+            .is_some_and(|node| matches!(node.value(), Node::Relation(_)))
     }
 
     pub fn schema_exists(&self, name: &str) -> bool {
         self.storage
             .get(name)
-            .map_or(false, |node| matches!(node.value(), Node::Namespace(_)))
+            .is_some_and(|node| matches!(node.value(), Node::Namespace(_)))
     }
 
     pub fn catalog(&self) -> Arc<dyn Catalog> {

--- a/datafusion_iceberg/src/catalog/mirror.rs
+++ b/datafusion_iceberg/src/catalog/mirror.rs
@@ -181,15 +181,15 @@ impl Mirror {
             .map_err(DataFusionError::from)
     }
     pub fn table_exists(&self, identifier: Identifier) -> bool {
-        self.storage.get(&identifier.to_string()).map_or(false, |node| {
-            matches!(node.value(), Node::Relation(_))
-        })
+        self.storage
+            .get(&identifier.to_string())
+            .map_or(false, |node| matches!(node.value(), Node::Relation(_)))
     }
 
     pub fn schema_exists(&self, name: &str) -> bool {
-        self.storage.get(name).map_or(false, |node| {
-            matches!(node.value(), Node::Namespace(_))
-        })
+        self.storage
+            .get(name)
+            .map_or(false, |node| matches!(node.value(), Node::Namespace(_)))
     }
 
     pub fn catalog(&self) -> Arc<dyn Catalog> {
@@ -213,21 +213,8 @@ impl Mirror {
                     _ => None,
                 });
 
-        let handle = Handle::current();
-        handle.spawn({
-            let catalog = self.catalog.clone();
-            let storage = self.storage.clone();
-            async move {
-                catalog
-                    .clone()
-                    .create_namespace(&namespace, None)
-                    .await
-                    .map_err(|err| DataFusionError::External(Box::new(err)))
-                    .unwrap();
-
-                storage.insert(namespace.to_string(), Node::Namespace(HashSet::new()));
-            }
-        });
+        self.storage
+            .insert(namespace.to_string(), Node::Namespace(HashSet::new()));
         Ok(old_value)
     }
 }

--- a/datafusion_iceberg/src/catalog/mirror.rs
+++ b/datafusion_iceberg/src/catalog/mirror.rs
@@ -204,16 +204,14 @@ impl Mirror {
         )
         .map_err(|err| DataFusionError::External(Box::new(err)))?;
 
-        let old_value =
-            self.storage
-                .get(&namespace.to_string())
-                .and_then(|entry| match entry.value() {
-                    Node::Namespace(namespace_node) => Some(namespace_node.clone()),
-                    _ => None,
-                });
+        let old_value = self
+            .storage
+            .insert(namespace.to_string(), Node::Namespace(HashSet::new()))
+            .and_then(|entry| match entry {
+                Node::Namespace(namespace_node) => Some(namespace_node.clone()),
+                _ => None,
+            });
 
-        self.storage
-            .insert(namespace.to_string(), Node::Namespace(HashSet::new()));
         Ok(old_value)
     }
 

--- a/datafusion_iceberg/src/catalog/mirror.rs
+++ b/datafusion_iceberg/src/catalog/mirror.rs
@@ -181,7 +181,9 @@ impl Mirror {
             .map_err(DataFusionError::from)
     }
     pub fn table_exists(&self, identifier: Identifier) -> bool {
-        self.storage.contains_key(&identifier.to_string())
+        self.storage.get(&identifier.to_string()).map_or(false, |node| {
+            matches!(node.value(), Node::Relation(_))
+        })
     }
 
     pub fn schema_exists(&self, name: &str) -> bool {

--- a/datafusion_iceberg/src/materialized_view/delta_queries/mod.rs
+++ b/datafusion_iceberg/src/materialized_view/delta_queries/mod.rs
@@ -121,6 +121,19 @@ mod tests {
             .await
             .expect("Failed to execute query plan.");
 
+        let sql = &"CREATE SCHEMA warehouse.tpch;".to_string();
+
+        let plan = ctx.state().create_logical_plan(sql).await.unwrap();
+
+        let transformed = plan.transform(iceberg_transform).data().unwrap();
+
+        ctx.execute_logical_plan(transformed)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .expect("Failed to execute query plan.");
+
         let sql = &format!("CREATE EXTERNAL TABLE warehouse.tpch.lineitem ( 
     L_ORDERKEY BIGINT NOT NULL, 
     L_PARTKEY BIGINT NOT NULL, 
@@ -559,6 +572,19 @@ WHERE L_SHIPDATE >= '1996-01-01';
             .await
             .expect("Failed to execute query plan.");
 
+        let sql = &"CREATE SCHEMA warehouse.tpch;".to_string();
+
+        let plan = ctx.state().create_logical_plan(sql).await.unwrap();
+
+        let transformed = plan.transform(iceberg_transform).data().unwrap();
+
+        ctx.execute_logical_plan(transformed)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .expect("Failed to execute query plan.");
+
         let sql = &format!("CREATE EXTERNAL TABLE warehouse.tpch.lineitem ( 
     L_ORDERKEY BIGINT NOT NULL, 
     L_PARTKEY BIGINT NOT NULL, 
@@ -982,6 +1008,19 @@ WHERE L_SHIPDATE >= '1996-01-01';
             .await
             .expect("Failed to execute query plan.");
 
+        let sql = &"CREATE SCHEMA warehouse.tpch;".to_string();
+
+        let plan = ctx.state().create_logical_plan(sql).await.unwrap();
+
+        let transformed = plan.transform(iceberg_transform).data().unwrap();
+
+        ctx.execute_logical_plan(transformed)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .expect("Failed to execute query plan.");
+
         let sql = &format!("CREATE EXTERNAL TABLE warehouse.tpch.lineitem ( 
     L_ORDERKEY BIGINT NOT NULL, 
     L_PARTKEY BIGINT NOT NULL, 
@@ -1276,6 +1315,19 @@ WHERE L_SHIPDATE >= '1996-01-01';
         L_SHIPINSTRUCT VARCHAR NOT NULL,
         L_SHIPMODE VARCHAR NOT NULL,
         L_COMMENT VARCHAR NOT NULL ) STORED AS CSV LOCATION '../datafusion_iceberg/testdata/tpch/lineitem_1.csv' OPTIONS ('has_header' 'false');";
+
+        let plan = ctx.state().create_logical_plan(sql).await.unwrap();
+
+        let transformed = plan.transform(iceberg_transform).data().unwrap();
+
+        ctx.execute_logical_plan(transformed)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .expect("Failed to execute query plan.");
+
+        let sql = &"CREATE SCHEMA warehouse.tpch;".to_string();
 
         let plan = ctx.state().create_logical_plan(sql).await.unwrap();
 

--- a/datafusion_iceberg/src/materialized_view/mod.rs
+++ b/datafusion_iceberg/src/materialized_view/mod.rs
@@ -470,6 +470,19 @@ mod tests {
             iceberg_catalog_list,
         )));
 
+        let sql = &"CREATE SCHEMA warehouse.public;".to_string();
+
+        let plan = ctx.state().create_logical_plan(sql).await.unwrap();
+
+        let transformed = plan.transform(iceberg_transform).data().unwrap();
+
+        ctx.execute_logical_plan(transformed)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .expect("Failed to execute query plan.");
+
         let sql = "CREATE EXTERNAL TABLE warehouse.public.orders (
       id BIGINT NOT NULL,
       order_date DATE NOT NULL,

--- a/datafusion_iceberg/src/table.rs
+++ b/datafusion_iceberg/src/table.rs
@@ -1046,6 +1046,7 @@ mod tests {
         catalog::tabular::Tabular,
         object_store::ObjectStoreBuilder,
         spec::{
+            namespace::Namespace,
             partition::{PartitionField, Transform},
             schema::Schema,
             types::{PrimitiveType, StructField, Type},
@@ -1487,6 +1488,11 @@ mod tests {
                 .await
                 .unwrap(),
         );
+
+        catalog
+            .create_namespace(&Namespace::try_new(&["test".to_owned()]).unwrap(), None)
+            .await
+            .unwrap();
 
         let schema = Schema::builder()
             .with_struct_field(StructField {

--- a/datafusion_iceberg/tests/empty_insert.rs
+++ b/datafusion_iceberg/tests/empty_insert.rs
@@ -108,6 +108,19 @@ pub async fn test_empty_insert() {
         .await
         .expect("Failed to execute query plan.");
 
+    let sql = &"CREATE SCHEMA warehouse.tpch;".to_string();
+
+    let plan = ctx.state().create_logical_plan(sql).await.unwrap();
+
+    let transformed = plan.transform(iceberg_transform).data().unwrap();
+
+    ctx.execute_logical_plan(transformed)
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .expect("Failed to execute query plan.");
+
     let sql = "CREATE EXTERNAL TABLE warehouse.tpch.lineitem ( 
     L_ORDERKEY BIGINT NOT NULL, 
     L_PARTKEY BIGINT NOT NULL, 

--- a/datafusion_iceberg/tests/equality_delete.rs
+++ b/datafusion_iceberg/tests/equality_delete.rs
@@ -3,6 +3,7 @@ use datafusion_iceberg::catalog::catalog::IcebergCatalog;
 use futures::stream;
 use iceberg_rust::catalog::identifier::Identifier;
 use iceberg_rust::catalog::tabular::Tabular;
+use iceberg_rust::spec::namespace::Namespace;
 use iceberg_rust::{
     arrow::write::write_equality_deletes_parquet_partitioned,
     catalog::Catalog,
@@ -26,6 +27,11 @@ pub async fn test_equality_delete() {
             .await
             .unwrap(),
     );
+
+    catalog
+        .create_namespace(&Namespace::try_new(&["test".to_string()]).unwrap(), None)
+        .await
+        .unwrap();
 
     let schema = Schema::builder()
         .with_struct_field(StructField {


### PR DESCRIPTION
## Summary
• Add schema existence checking to catalog mirror
• Implement schema registration and deregistration functionality
• Fix table_exists method to properly check for relation nodes
• Add deregister_schema method for schema cleanup

🤖 Generated with [Claude Code](https://claude.ai/code)