### PR TITLE
Allow parquet writes for Struct data type

### DIFF
--- a/iceberg-rust-spec/src/spec/types.rs
+++ b/iceberg-rust-spec/src/spec/types.rs
@@ -319,7 +319,7 @@ impl StructType {
                 .iter()
                 .find(|field| field.name == *part);
 
-            if i == parts.len() - 1 || current_field.is_none() {
+            if i == parts.len() - 1 || current_field.is_some() {
                 return current_field;
             }
 

--- a/iceberg-rust/src/file_format/parquet.rs
+++ b/iceberg-rust/src/file_format/parquet.rs
@@ -63,7 +63,7 @@ pub fn parquet_to_datafile(
         for column in row_group.columns() {
             let column_name = column.column_descr().name();
             let id = schema
-                .get_name(column_name)
+                .get_name(&column.column_path().parts().join("."))
                 .ok_or_else(|| Error::Schema(column_name.to_string(), "".to_string()))?
                 .id;
             column_sizes


### PR DESCRIPTION
Related to https://github.com/Embucket/embucket/issues/1352
only **column.column_path().parts()** cointains full path for column for Struct type
```rust
pub fn get_name(&self, name: &str) -> Option<&StructField> {
        let res = self.fields.iter().find(|field| field.name == name);
        if res.is_some() {
            return res;
        }
        let parts: Vec<&str> = name.split('.').collect();
        let mut current_struct = self;
        let mut current_field = None;
...
```

Example of arrow schema
```rust
arrow_schema Schema { fields: [Field { name: "address", data_type: Struct([Field { name: "state", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {"PARQUET:field_id": "2"} }, Field { name: "city", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {"PARQUET:field_id": "3"} }, Field { name: "street", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {"PARQUET:field_id": "4"} }, Field { name: "zip_code", data_type: Decimal128(38, 0), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {"PARQUET:field_id": "5"} }]), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {"PARQUET:field_id": "1"} }], metadata: {} }
```
for insert statement
```sql
CREATE TABLE customer (
  address OBJECT(
    state VARCHAR,
    city VARCHAR,
    street VARCHAR,
    zip_code NUMBER
  )
);
INSERT INTO customer SELECT
  {
    'state': 'CA',
    'city': 'San Mateo',
    'street': '450 Concar Drive',
    'zip_code': 94402
  }::OBJECT(
    state VARCHAR,
    city VARCHAR,
    street VARCHAR,
    zip_code NUMBER
  );
```
