### PR TITLE
fix: write delete files to separate manifest list entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,7 @@ version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7686986a3bf2254c9fb130c623cdcb2f8e1f15763e7c71c310f0834da3d292"
 dependencies = [
+ "bitflags 2.9.0",
  "serde",
  "serde_json",
 ]
@@ -1347,6 +1348,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2292,6 +2299,7 @@ dependencies = [
  "datafusion",
  "datafusion-expr",
  "derive_builder",
+ "duckdb",
  "futures",
  "iceberg-rest-catalog",
  "iceberg-rust",
@@ -2417,6 +2425,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "duckdb"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ab83a22530667ffc8cc0e31c0549bb07bea5dba3b957a8e315effc38923701"
+dependencies = [
+ "arrow",
+ "cast",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libduckdb-sys",
+ "num-integer",
+ "rust_decimal",
+ "smallvec",
+ "strum",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,6 +2519,18 @@ dependencies = [
  "event-listener 5.4.0",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -3706,6 +3744,21 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libduckdb-sys"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e02f6069513efb67a0743aff3b846090de14763802b0e95c352ebc6e1bdc1da"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "serde",
+ "serde_json",
+ "tar",
+ "vcpkg",
+]
 
 [[package]]
 name = "libloading"
@@ -5680,6 +5733,9 @@ name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
@@ -5768,6 +5824,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "tempfile"

--- a/catalogs/iceberg-file-catalog/src/lib.rs
+++ b/catalogs/iceberg-file-catalog/src/lib.rs
@@ -506,7 +506,7 @@ impl Catalog for FileCatalog {
         _identifier: Identifier,
         _metadata_location: &str,
     ) -> Result<Table, IcebergError> {
-        unimplemented!("Register table for file catalog")
+        unimplemented!()
     }
 }
 

--- a/datafusion_iceberg/Cargo.toml
+++ b/datafusion_iceberg/Cargo.toml
@@ -29,6 +29,7 @@ url = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+duckdb = { version = "1.3.2", features = ["bundled"] }
 iceberg-rest-catalog = { path = "../catalogs/iceberg-rest-catalog" }
 iceberg-sql-catalog = { path = "../catalogs/iceberg-sql-catalog" }
 reqwest = "0.12"

--- a/iceberg-rust-spec/src/spec/values.rs
+++ b/iceberg-rust-spec/src/spec/values.rs
@@ -670,7 +670,7 @@ impl Value {
                 precision: 38,
                 scale: dec.scale(),
             }),
-            _ => unimplemented!("Datatype for value"),
+            _ => unimplemented!(),
         }
     }
 
@@ -698,7 +698,7 @@ impl Value {
             Value::String(any) => Box::new(any),
             Value::UUID(any) => Box::new(any),
             Value::Decimal(any) => Box::new(any),
-            _ => unimplemented!("Value conversion to any"),
+            _ => unimplemented!(),
         }
     }
 

--- a/iceberg-rust/src/catalog/commit.rs
+++ b/iceberg-rust/src/catalog/commit.rs
@@ -423,7 +423,7 @@ pub fn apply_table_updates(
                 if i32::from(metadata.format_version) == format_version {
                     return Ok(());
                 }
-                unimplemented!("Table format upgrade");
+                unimplemented!();
             }
             TableUpdate::AssignUuid { uuid } => {
                 metadata.table_uuid = Uuid::parse_str(&uuid)?;

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -183,6 +183,7 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         schema: &'schema AvroSchema,
         table_metadata: &'metadata TableMetadata,
         branch: Option<&str>,
+        content: manifest_list::Content,
     ) -> Result<Self, Error> {
         let mut writer = AvroWriter::new(schema, Vec::new());
 
@@ -236,7 +237,7 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             manifest_path: manifest_location.to_owned(),
             manifest_length: 0,
             partition_spec_id: table_metadata.default_spec_id,
-            content: manifest_list::Content::Data,
+            content,
             sequence_number: table_metadata.last_sequence_number + 1,
             min_sequence_number: table_metadata.last_sequence_number + 1,
             added_snapshot_id: snapshot_id,


### PR DESCRIPTION
- make sure manifest list entries are exclusively for data or delete content, and never mixed, since that will confuse other readers
- when executing the append operation try to find and re-use an existing manifest list entry with content that has the most files to add, instead of always appending to data entries
- extend the equality delete integration test, and verify DuckDB can read it correctly as well

Closes #212.