### PR TITLE
use separate manifest files for delete files

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
         android: true
         dotnet: true
         haskell: true
-        large-packages: false
+        large-packages: true
         docker-images: false
         swap-storage: false
     - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,7 @@ version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7686986a3bf2254c9fb130c623cdcb2f8e1f15763e7c71c310f0834da3d292"
 dependencies = [
+ "bitflags 2.9.0",
  "serde",
  "serde_json",
 ]
@@ -1347,6 +1348,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2292,6 +2299,7 @@ dependencies = [
  "datafusion",
  "datafusion-expr",
  "derive_builder",
+ "duckdb",
  "futures",
  "iceberg-rest-catalog",
  "iceberg-rust",
@@ -2417,6 +2425,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "duckdb"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ab83a22530667ffc8cc0e31c0549bb07bea5dba3b957a8e315effc38923701"
+dependencies = [
+ "arrow",
+ "cast",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libduckdb-sys",
+ "num-integer",
+ "rust_decimal",
+ "smallvec",
+ "strum",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,6 +2519,18 @@ dependencies = [
  "event-listener 5.4.0",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -3706,6 +3744,21 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libduckdb-sys"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e02f6069513efb67a0743aff3b846090de14763802b0e95c352ebc6e1bdc1da"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "serde",
+ "serde_json",
+ "tar",
+ "vcpkg",
+]
 
 [[package]]
 name = "libloading"
@@ -5680,6 +5733,9 @@ name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
@@ -5768,6 +5824,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "tempfile"

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,16 @@ test-iceberg-rust:
 	cargo test -p iceberg-rust --lib
 
 test-datafusion_iceberg:
-	cargo test -p datafusion_iceberg --tests -j 2 
+	cargo test -p datafusion_iceberg --tests -j 2 && cargo clean -p datafusion_iceberg
 
 test-rest-catalog:
-	cargo test -p iceberg-rest-catalog --lib 
+	cargo test -p iceberg-rest-catalog --lib && cargo clean -p iceberg-rest-catalog
 
 test-file-catalog:
-	cargo test -p iceberg-file-catalog --lib 
+	cargo test -p iceberg-file-catalog --lib && cargo clean -p iceberg-file-catalog
 
 test-sql-catalog:
-	cargo test -p iceberg-sql-catalog --lib 
+	cargo test -p iceberg-sql-catalog --lib && cargo clean -p iceberg-sql-catalog
 clippy:
 	cargo clippy --all-targets --all-features -- -D warnings
 fmt:

--- a/datafusion_iceberg/Cargo.toml
+++ b/datafusion_iceberg/Cargo.toml
@@ -29,6 +29,7 @@ url = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+duckdb = { version = "1.3.2", features = ["bundled"] }
 iceberg-rest-catalog = { path = "../catalogs/iceberg-rest-catalog" }
 iceberg-sql-catalog = { path = "../catalogs/iceberg-sql-catalog" }
 reqwest = "0.12"

--- a/datafusion_iceberg/tests/equality_delete.rs
+++ b/datafusion_iceberg/tests/equality_delete.rs
@@ -1,5 +1,10 @@
-use datafusion::{arrow::error::ArrowError, assert_batches_eq, prelude::SessionContext};
+use datafusion::{
+    arrow::{error::ArrowError, record_batch::RecordBatch},
+    assert_batches_eq,
+    prelude::SessionContext,
+};
 use datafusion_iceberg::catalog::catalog::IcebergCatalog;
+use duckdb::Connection;
 use futures::stream;
 use iceberg_rust::catalog::identifier::Identifier;
 use iceberg_rust::catalog::tabular::Tabular;
@@ -16,11 +21,15 @@ use iceberg_rust::{
     table::Table,
 };
 use iceberg_sql_catalog::SqlCatalog;
+use object_store::local::LocalFileSystem;
 use std::sync::Arc;
+use tempfile::TempDir;
 
 #[tokio::test]
 pub async fn test_equality_delete() {
-    let object_store = ObjectStoreBuilder::memory();
+    let temp_dir = TempDir::new().unwrap();
+    let table_dir = format!("{}/test/orders", temp_dir.path().to_str().unwrap());
+    let object_store = ObjectStoreBuilder::Filesystem(Arc::new(LocalFileSystem::new()));
 
     let catalog: Arc<dyn Catalog> = Arc::new(
         SqlCatalog::new("sqlite://", "warehouse", object_store.clone())
@@ -79,7 +88,7 @@ pub async fn test_equality_delete() {
 
     let table = Table::builder()
         .with_name("orders")
-        .with_location("/test/orders")
+        .with_location(&table_dir)
         .with_schema(schema)
         .with_partition_spec(partition_spec)
         .build(&["test".to_owned()], catalog.clone())
@@ -194,4 +203,28 @@ pub async fn test_equality_delete() {
         "+----+-------------+------------+------------+--------+",
     ];
     assert_batches_eq!(expected, &batches);
+
+    let latest_version = table
+        .object_store()
+        .get(&object_store::path::Path::from(format!(
+            "{table_dir}/metadata/version-hint.text"
+        )))
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    let latest_version_str = std::str::from_utf8(&latest_version).unwrap();
+
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute("install iceberg", []).unwrap();
+    conn.execute("load iceberg", []).unwrap();
+
+    let duckdb_batches: Vec<RecordBatch> = conn
+        .prepare("select * from iceberg_scan(?) order by id")
+        .unwrap()
+        .query_arrow([latest_version_str])
+        .unwrap()
+        .collect();
+    assert_batches_eq!(expected, &duckdb_batches);
 }

--- a/iceberg-rust-spec/src/spec/manifest_list.rs
+++ b/iceberg-rust-spec/src/spec/manifest_list.rs
@@ -94,7 +94,7 @@ pub struct FieldSummary {
     pub upper_bound: Option<Value>,
 }
 
-#[derive(Debug, Serialize_repr, Deserialize_repr, PartialEq, Eq, Clone)]
+#[derive(Debug, Serialize_repr, Deserialize_repr, PartialEq, Eq, Clone, Copy)]
 #[repr(u8)]
 /// Type of content stored by the data file.
 pub enum Content {

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -182,6 +182,7 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         snapshot_id: i64,
         schema: &'schema AvroSchema,
         table_metadata: &'metadata TableMetadata,
+        content: manifest_list::Content,
         branch: Option<&str>,
     ) -> Result<Self, Error> {
         let mut writer = AvroWriter::new(schema, Vec::new());
@@ -229,14 +230,20 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             serde_json::to_string(&spec_id)?,
         )?;
 
-        writer.add_user_metadata("content".to_string(), "data")?;
+        writer.add_user_metadata(
+            "content".to_string(),
+            match content {
+                manifest_list::Content::Data => "data",
+                manifest_list::Content::Deletes => "deletes",
+            },
+        )?;
 
         let manifest = ManifestListEntry {
             format_version: table_metadata.format_version,
             manifest_path: manifest_location.to_owned(),
             manifest_length: 0,
             partition_spec_id: table_metadata.default_spec_id,
-            content: manifest_list::Content::Data,
+            content,
             sequence_number: table_metadata.last_sequence_number + 1,
             min_sequence_number: table_metadata.last_sequence_number + 1,
             added_snapshot_id: snapshot_id,
@@ -331,7 +338,13 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             serde_json::to_string(&spec_id)?,
         )?;
 
-        writer.add_user_metadata("content".to_string(), "data")?;
+        writer.add_user_metadata(
+            "content".to_string(),
+            match manifest.content {
+                manifest_list::Content::Data => "data",
+                manifest_list::Content::Deletes => "deletes",
+            },
+        )?;
 
         writer.extend(
             manifest_reader
@@ -455,7 +468,13 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             serde_json::to_string(&spec_id)?,
         )?;
 
-        writer.add_user_metadata("content".to_string(), "data")?;
+        writer.add_user_metadata(
+            "content".to_string(),
+            match manifest.content {
+                manifest_list::Content::Data => "data",
+                manifest_list::Content::Deletes => "deletes",
+            },
+        )?;
 
         writer.extend(manifest_reader.filter_map(|entry| {
             let mut entry = entry

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -988,10 +988,18 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     }
 
     pub(crate) async fn finish(
-        self,
+        mut self,
         snapshot_id: i64,
         object_store: Arc<dyn ObjectStore>,
     ) -> Result<String, Error> {
+        if let Some(selected_data_manifest) = self.selected_data_manifest.take() {
+            self.writer.append_ser(selected_data_manifest)?;
+        }
+
+        if let Some(selected_delete_manifest) = self.selected_delete_manifest.take() {
+            self.writer.append_ser(selected_delete_manifest)?;
+        }
+
         let new_manifest_list_location = new_manifest_list_location(
             &self.table_metadata.location,
             snapshot_id,

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -533,9 +533,12 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     /// ```ignore
     /// let splits = writer.n_splits(1000); // Calculate splits for 1000 new files
     /// ```
-    pub(crate) fn n_splits(&self, n_data_files: usize) -> u32 {
-        let selected_manifest_file_count = self
-            .selected_data_manifest
+    pub(crate) fn n_splits(&self, n_data_files: usize, content: Content) -> u32 {
+        let selected_manifest = match content {
+            Content::Data => &self.selected_data_manifest,
+            Content::Deletes => &self.selected_delete_manifest,
+        };
+        let selected_manifest_file_count = selected_manifest
             .as_ref()
             .and_then(|selected_manifest| {
                 match (

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -733,6 +733,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                 snapshot_id,
                 &manifest_schema,
                 self.table_metadata,
+                content,
                 self.branch.as_deref(),
             )?
         };
@@ -965,6 +966,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                     snapshot_id,
                     &manifest_schema,
                     self.table_metadata,
+                    content,
                     self.branch.as_deref(),
                 )?;
 

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -600,7 +600,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     ///
     /// # Example Usage
     /// ```ignore
-    /// let manifest_list_location = writer.append_and_finish(
+    /// let manifest_list_location = writer.append(
     ///     data_files_iter,
     ///     snapshot_id,
     ///     object_store,
@@ -626,7 +626,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
 
     /// Appends data files to a single manifest with optional filtering and finalizes the manifest list.
     ///
-    /// This method extends the basic `append_and_finish` functionality by providing the ability to
+    /// This method extends the basic `append` functionality by providing the ability to
     /// filter data files during the append process. It creates a single manifest file containing
     /// the provided data files (after filtering), either by appending to an existing reusable
     /// manifest or creating a new one.
@@ -671,7 +671,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     ///
     /// # Example Usage
     /// ```ignore
-    /// let manifest_list_location = writer.append_filtered_and_finish(
+    /// let manifest_list_location = writer.append_filtered(
     ///     data_files_iter,
     ///     snapshot_id,
     ///     Some(|entry| entry.as_ref().map(|e| e.status() == &Status::Added).unwrap_or(false)),
@@ -792,7 +792,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     /// # Example Usage
     /// ```ignore
     /// let n_splits = writer.n_splits(data_files.len());
-    /// let manifest_list_location = writer.append_split_and_finish(
+    /// let manifest_list_location = writer.append_split(
     ///     data_files_iter,
     ///     snapshot_id,
     ///     n_splits,
@@ -820,7 +820,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
 
     /// Appends data files across multiple manifests with optional filtering and finalizes the manifest list.
     ///
-    /// This method extends the `append_multiple_and_finish` functionality by providing the ability to
+    /// This method extends the `append_multiple` functionality by providing the ability to
     /// filter data files during the append and splitting process. It distributes the data files
     /// (after filtering) across the specified number of splits based on partition boundaries,
     /// optimizing for large operations that require conditional processing.
@@ -871,7 +871,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     /// # Example Usage
     /// ```ignore
     /// let n_splits = writer.n_splits(data_files.len());
-    /// let manifest_list_location = writer.append_multiple_filtered_and_finish(
+    /// let manifest_list_location = writer.append_multiple_filtered(
     ///     data_files_iter,
     ///     snapshot_id,
     ///     n_splits,

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -17,7 +17,7 @@ use iceberg_rust_spec::{
     manifest::{partition_value_schema, DataFile, ManifestEntry, Status},
     manifest_list::{
         avro_value_to_manifest_list_entry, manifest_list_schema_v1, manifest_list_schema_v2,
-        ManifestListEntry,
+        Content, ManifestListEntry,
     },
     snapshot::Snapshot,
     table_metadata::{FormatVersion, TableMetadata},
@@ -245,7 +245,8 @@ pub async fn snapshot_partition_bounds(
 pub(crate) struct ManifestListWriter<'schema, 'metadata> {
     table_metadata: &'metadata TableMetadata,
     writer: AvroWriter<'schema, Vec<u8>>,
-    selected_manifest: Option<ManifestListEntry>,
+    selected_data_manifest: Option<ManifestListEntry>,
+    selected_delete_manifest: Option<ManifestListEntry>,
     bounding_partition_values: Rectangle,
     n_existing_files: usize,
     commit_uuid: String,
@@ -306,7 +307,8 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         Ok(Self {
             table_metadata,
             writer,
-            selected_manifest: None,
+            selected_data_manifest: None,
+            selected_delete_manifest: None,
             bounding_partition_values,
             n_existing_files: 0,
             commit_uuid,
@@ -380,7 +382,8 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         let mut writer = AvroWriter::new(schema, Vec::new());
 
         let SelectedManifest {
-            manifest,
+            data_manifest,
+            delete_manifest,
             file_count_all_entries,
         } = if partition_column_names.is_empty() {
             select_manifest_unpartitioned(manifest_list_reader, &mut writer)?
@@ -395,7 +398,8 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         Ok(Self {
             table_metadata,
             writer,
-            selected_manifest: Some(manifest),
+            selected_data_manifest: Some(data_manifest),
+            selected_delete_manifest: delete_manifest,
             bounding_partition_values,
             n_existing_files: file_count_all_entries,
             commit_uuid,
@@ -497,7 +501,8 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             Self {
                 table_metadata,
                 writer,
-                selected_manifest: Some(manifest),
+                selected_data_manifest: Some(manifest),
+                selected_delete_manifest: None,
                 bounding_partition_values,
                 n_existing_files: file_count_all_entries,
                 commit_uuid,
@@ -530,7 +535,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     /// ```
     pub(crate) fn n_splits(&self, n_data_files: usize) -> u32 {
         let selected_manifest_file_count = self
-            .selected_manifest
+            .selected_data_manifest
             .as_ref()
             .and_then(|selected_manifest| {
                 match (
@@ -595,17 +600,19 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     /// ).await?;
     /// ```
     #[inline]
-    pub(crate) async fn append_and_finish(
-        self,
+    pub(crate) async fn append(
+        &mut self,
         data_files: impl Iterator<Item = Result<ManifestEntry, Error>>,
         snapshot_id: i64,
         object_store: Arc<dyn ObjectStore>,
-    ) -> Result<String, Error> {
-        self.append_filtered_and_finish(
+        content: Content,
+    ) -> Result<(), Error> {
+        self.append_filtered(
             data_files,
             snapshot_id,
             None::<fn(&Result<ManifestEntry, Error>) -> bool>,
             object_store,
+            content,
         )
         .await
     }
@@ -664,14 +671,19 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     ///     object_store,
     /// ).await?;
     /// ```
-    pub(crate) async fn append_filtered_and_finish(
-        mut self,
+    pub(crate) async fn append_filtered(
+        &mut self,
         data_files: impl Iterator<Item = Result<ManifestEntry, Error>>,
         snapshot_id: i64,
         filter: Option<impl Fn(&Result<ManifestEntry, Error>) -> bool>,
         object_store: Arc<dyn ObjectStore>,
-    ) -> Result<String, Error> {
-        let selected_manifest_bytes_opt = prefetch_manifest(&self.selected_manifest, &object_store);
+        content: Content,
+    ) -> Result<(), Error> {
+        let selected_manifest = match content {
+            Content::Data => self.selected_data_manifest.take(),
+            Content::Deletes => self.selected_delete_manifest.take(),
+        };
+        let selected_manifest_bytes_opt = prefetch_manifest(&selected_manifest, &object_store);
 
         let partition_fields = self
             .table_metadata
@@ -683,7 +695,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         )?;
 
         let mut manifest_writer = if let (Some(mut manifest), Some(manifest_bytes)) =
-            (self.selected_manifest, selected_manifest_bytes_opt)
+            (selected_manifest, selected_manifest_bytes_opt)
         {
             let manifest_bytes = manifest_bytes.await??;
 
@@ -730,23 +742,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
 
         self.writer.append_ser(manifest)?;
 
-        let new_manifest_list_location = new_manifest_list_location(
-            &self.table_metadata.location,
-            snapshot_id,
-            0,
-            &self.commit_uuid,
-        );
-
-        let manifest_list_bytes = self.writer.into_inner()?;
-
-        object_store
-            .put(
-                &strip_prefix(&new_manifest_list_location).into(),
-                manifest_list_bytes.into(),
-            )
-            .await?;
-
-        Ok(new_manifest_list_location)
+        Ok(())
     }
 
     /// Appends data files by splitting them across multiple manifests and finalizes the manifest list.
@@ -797,19 +793,21 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     ///     object_store,
     /// ).await?;
     /// ```
-    pub(crate) async fn append_multiple_and_finish(
-        self,
+    pub(crate) async fn append_multiple(
+        &mut self,
         data_files: impl Iterator<Item = Result<ManifestEntry, Error>>,
         snapshot_id: i64,
         n_splits: u32,
         object_store: Arc<dyn ObjectStore>,
-    ) -> Result<String, Error> {
-        self.append_multiple_filtered_and_finish(
+        content: Content,
+    ) -> Result<(), Error> {
+        self.append_multiple_filtered(
             data_files,
             snapshot_id,
             n_splits,
             None::<fn(&Result<ManifestEntry, Error>) -> bool>,
             object_store,
+            content,
         )
         .await
     }
@@ -875,14 +873,15 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     ///     object_store,
     /// ).await?;
     /// ```
-    pub(crate) async fn append_multiple_filtered_and_finish(
-        mut self,
+    pub(crate) async fn append_multiple_filtered(
+        &mut self,
         data_files: impl Iterator<Item = Result<ManifestEntry, Error>>,
         snapshot_id: i64,
         n_splits: u32,
         filter: Option<impl Fn(&Result<ManifestEntry, Error>) -> bool>,
         object_store: Arc<dyn ObjectStore>,
-    ) -> Result<String, Error> {
+        content: Content,
+    ) -> Result<(), Error> {
         let partition_fields = self
             .table_metadata
             .current_partition_fields(self.branch.as_deref())?;
@@ -898,7 +897,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         )?;
 
         let bounds = self
-            .selected_manifest
+            .selected_data_manifest
             .as_ref()
             .and_then(|x| x.partitions.as_deref())
             .map(summary_to_rectangle)
@@ -907,13 +906,17 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                 x.expand(&self.bounding_partition_values);
                 x
             })
-            .unwrap_or(self.bounding_partition_values);
+            .unwrap_or(self.bounding_partition_values.clone());
 
-        let selected_manifest_bytes_opt = prefetch_manifest(&self.selected_manifest, &object_store);
+        let selected_manifest = match content {
+            Content::Data => self.selected_data_manifest.take(),
+            Content::Deletes => self.selected_delete_manifest.take(),
+        };
+        let selected_manifest_bytes_opt = prefetch_manifest(&selected_manifest, &object_store);
 
         // Split datafiles
         let splits = if let (Some(manifest), Some(manifest_bytes)) =
-            (self.selected_manifest, selected_manifest_bytes_opt)
+            (selected_manifest, selected_manifest_bytes_opt)
         {
             let manifest_bytes = manifest_bytes.await??;
             let manifest_reader = ManifestReader::new(&*manifest_bytes)?.map(|entry| {
@@ -976,6 +979,14 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             self.writer.append_ser(manifest)?;
         }
 
+        Ok(())
+    }
+
+    pub(crate) async fn finish(
+        self,
+        snapshot_id: i64,
+        object_store: Arc<dyn ObjectStore>,
+    ) -> Result<String, Error> {
         let new_manifest_list_location = new_manifest_list_location(
             &self.table_metadata.location,
             snapshot_id,
@@ -1122,6 +1133,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     }
 
     pub(crate) fn selected_manifest(&self) -> Option<&ManifestListEntry> {
-        self.selected_manifest.as_ref()
+        self.selected_data_manifest.as_ref()
     }
 }

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -250,6 +250,7 @@ pub(crate) struct ManifestListWriter<'schema, 'metadata> {
     bounding_partition_values: Rectangle,
     n_existing_files: usize,
     commit_uuid: String,
+    manifest_count: usize,
     branch: Option<String>,
 }
 
@@ -312,6 +313,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             bounding_partition_values,
             n_existing_files: 0,
             commit_uuid,
+            manifest_count: 0,
             branch: branch.map(ToOwned::to_owned),
         })
     }
@@ -403,6 +405,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             bounding_partition_values,
             n_existing_files: file_count_all_entries,
             commit_uuid,
+            manifest_count: 0,
             branch: branch.map(ToOwned::to_owned),
         })
     }
@@ -506,6 +509,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                 bounding_partition_values,
                 n_existing_files: file_count_all_entries,
                 commit_uuid,
+                manifest_count: 0,
                 branch: branch.map(ToOwned::to_owned),
             },
             manifests,
@@ -702,8 +706,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         {
             let manifest_bytes = manifest_bytes.await??;
 
-            manifest.manifest_path =
-                new_manifest_location(&self.table_metadata.location, &self.commit_uuid, 0);
+            manifest.manifest_path = self.next_manifest_location();
 
             let manifest_reader = ManifestReader::new(manifest_bytes.as_ref())?;
 
@@ -725,8 +728,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                 )?
             }
         } else {
-            let manifest_location =
-                new_manifest_location(&self.table_metadata.location, &self.commit_uuid, 0);
+            let manifest_location = self.next_manifest_location();
 
             ManifestWriter::new(
                 &manifest_location,
@@ -956,10 +958,8 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
 
         let manifest_futures = splits
             .into_iter()
-            .enumerate()
-            .map(|(i, entries)| {
-                let manifest_location =
-                    new_manifest_location(&self.table_metadata.location, &self.commit_uuid, i);
+            .map(|entries| {
+                let manifest_location = self.next_manifest_location();
 
                 let mut manifest_writer = ManifestWriter::new(
                     &manifest_location,
@@ -1078,7 +1078,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         data_files_to_filter: &HashMap<String, Vec<String>>,
         object_store: Arc<dyn ObjectStore>,
     ) -> Result<(), Error> {
-        let table_metadata = &self.table_metadata;
         let partition_fields = self
             .table_metadata
             .current_partition_fields(self.branch.as_deref())?;
@@ -1088,48 +1087,43 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             &self.table_metadata.format_version,
         )?);
 
-        let futures = manifests_to_overwrite
-            .into_iter()
-            .enumerate()
-            .map(|(i, mut manifest)| {
-                let object_store = object_store.clone();
-                let location = self.table_metadata.location.clone();
-                let commit_uuid = self.commit_uuid.clone();
-                let manifest_schema = manifest_schema.clone();
-                let branch = self.branch.clone();
-                async move {
-                    let data_files_to_filter: HashSet<String> = data_files_to_filter
-                        .get(&manifest.manifest_path)
-                        .ok_or(Error::NotFound("Datafiles for manifest".to_owned()))?
-                        .iter()
-                        .map(ToOwned::to_owned)
-                        .collect();
+        let futures = manifests_to_overwrite.into_iter().map(|mut manifest| {
+            let object_store = object_store.clone();
+            let manifest_schema = manifest_schema.clone();
+            let branch = self.branch.clone();
+            let manifest_location = self.next_manifest_location();
+            let table_metadata = self.table_metadata;
+            async move {
+                let data_files_to_filter: HashSet<String> = data_files_to_filter
+                    .get(&manifest.manifest_path)
+                    .ok_or(Error::NotFound("Datafiles for manifest".to_owned()))?
+                    .iter()
+                    .map(ToOwned::to_owned)
+                    .collect();
 
-                    let bytes = object_store
-                        .clone()
-                        .get(&strip_prefix(&manifest.manifest_path).into())
-                        .await?
-                        .bytes()
-                        .await?;
+                let bytes = object_store
+                    .clone()
+                    .get(&strip_prefix(&manifest.manifest_path).into())
+                    .await?
+                    .bytes()
+                    .await?;
 
-                    let manifest_location = new_manifest_location(&location, &commit_uuid, i);
+                manifest.manifest_path = manifest_location;
 
-                    manifest.manifest_path = manifest_location;
+                let manifest_writer = ManifestWriter::from_existing_with_filter(
+                    &bytes,
+                    manifest,
+                    &data_files_to_filter,
+                    &manifest_schema,
+                    table_metadata,
+                    branch.as_deref(),
+                )?;
 
-                    let manifest_writer = ManifestWriter::from_existing_with_filter(
-                        &bytes,
-                        manifest,
-                        &data_files_to_filter,
-                        &manifest_schema,
-                        table_metadata,
-                        branch.as_deref(),
-                    )?;
+                let new_manifest = manifest_writer.finish(object_store.clone()).await?;
 
-                    let new_manifest = manifest_writer.finish(object_store.clone()).await?;
-
-                    Ok::<_, Error>(new_manifest)
-                }
-            });
+                Ok::<_, Error>(new_manifest)
+            }
+        });
         for manifest_res in join_all(futures).await {
             let manifest = manifest_res?;
             self.writer.append_ser(manifest)?;
@@ -1139,5 +1133,15 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
 
     pub(crate) fn selected_manifest(&self) -> Option<&ManifestListEntry> {
         self.selected_data_manifest.as_ref()
+    }
+
+    /// Get the next manifest location, tracking and numbering preceding manifests written by this
+    /// writer.
+    fn next_manifest_location(&mut self) -> String {
+        let next_id = self.manifest_count;
+
+        self.manifest_count += 1;
+
+        new_manifest_location(&self.table_metadata.location, &self.commit_uuid, next_id)
     }
 }

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -325,6 +325,7 @@ impl Operation {
                         snapshot_id,
                         &manifest_schema,
                         table_metadata,
+                        Content::Data,
                         branch.as_deref(),
                     )?;
 
@@ -356,6 +357,7 @@ impl Operation {
                             snapshot_id,
                             &manifest_schema,
                             table_metadata,
+                            Content::Data,
                             branch.as_deref(),
                         )?;
 

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use bytes::Bytes;
 use iceberg_rust_spec::manifest_list::{
-    manifest_list_schema_v1, manifest_list_schema_v2, ManifestListEntry,
+    manifest_list_schema_v1, manifest_list_schema_v2, Content, ManifestListEntry,
 };
 use iceberg_rust_spec::snapshot::{Operation as SnapshotOperation, Snapshot};
 use iceberg_rust_spec::spec::table_metadata::TableMetadata;
@@ -118,7 +118,7 @@ impl Operation {
 
                 let data_files_iter = delete_files.iter().chain(data_files.iter());
 
-                let manifest_list_writer = if let Some(manifest_list_bytes) =
+                let mut manifest_list_writer = if let Some(manifest_list_bytes) =
                     prefetch_manifest_list(old_snapshot, &object_store)
                 {
                     let bytes = manifest_list_bytes.await??;
@@ -140,19 +140,25 @@ impl Operation {
 
                 let n_splits = manifest_list_writer.n_splits(n_data_files + n_delete_files);
 
-                let new_datafile_iter =
-                    delete_files
-                        .into_iter()
-                        .chain(data_files.into_iter())
-                        .map(|data_file| {
-                            ManifestEntry::builder()
-                                .with_format_version(table_metadata.format_version)
-                                .with_status(Status::Added)
-                                .with_data_file(data_file)
-                                .build()
-                                .map_err(crate::spec::error::Error::from)
-                                .map_err(Error::from)
-                        });
+                let new_datafile_iter = data_files.into_iter().map(|data_file| {
+                    ManifestEntry::builder()
+                        .with_format_version(table_metadata.format_version)
+                        .with_status(Status::Added)
+                        .with_data_file(data_file)
+                        .build()
+                        .map_err(crate::spec::error::Error::from)
+                        .map_err(Error::from)
+                });
+
+                let new_delete_iter = delete_files.into_iter().map(|data_file| {
+                    ManifestEntry::builder()
+                        .with_format_version(table_metadata.format_version)
+                        .with_status(Status::Added)
+                        .with_data_file(data_file)
+                        .build()
+                        .map_err(crate::spec::error::Error::from)
+                        .map_err(Error::from)
+                });
 
                 let snapshot_id = generate_snapshot_id();
 
@@ -160,16 +166,45 @@ impl Operation {
                 // Split manifest file if limit is exceeded
                 let new_manifest_list_location = if n_splits == 0 {
                     manifest_list_writer
-                        .append_and_finish(new_datafile_iter, snapshot_id, object_store)
+                        .append(
+                            new_datafile_iter,
+                            snapshot_id,
+                            object_store.clone(),
+                            Content::Data,
+                        )
+                        .await?;
+                    manifest_list_writer
+                        .append(
+                            new_delete_iter,
+                            snapshot_id,
+                            object_store.clone(),
+                            Content::Deletes,
+                        )
+                        .await?;
+                    manifest_list_writer
+                        .finish(snapshot_id, object_store)
                         .await?
                 } else {
                     manifest_list_writer
-                        .append_multiple_and_finish(
+                        .append_multiple(
                             new_datafile_iter,
                             snapshot_id,
                             n_splits,
-                            object_store,
+                            object_store.clone(),
+                            Content::Data,
                         )
+                        .await?;
+                    manifest_list_writer
+                        .append_multiple(
+                            new_delete_iter,
+                            snapshot_id,
+                            n_splits,
+                            object_store.clone(),
+                            Content::Deletes,
+                        )
+                        .await?;
+                    manifest_list_writer
+                        .finish(snapshot_id, object_store)
                         .await?
                 };
 
@@ -452,22 +487,30 @@ impl Operation {
                 // Split manifest file if limit is exceeded
                 let new_manifest_list_location = if n_splits == 0 {
                     manifest_list_writer
-                        .append_filtered_and_finish(
+                        .append_filtered(
                             new_datafile_iter,
                             snapshot_id,
                             filter,
-                            object_store,
+                            object_store.clone(),
+                            Content::Data,
                         )
+                        .await?;
+                    manifest_list_writer
+                        .finish(snapshot_id, object_store)
                         .await?
                 } else {
                     manifest_list_writer
-                        .append_multiple_filtered_and_finish(
+                        .append_multiple_filtered(
                             new_datafile_iter,
                             snapshot_id,
                             n_splits,
                             filter,
-                            object_store,
+                            object_store.clone(),
+                            Content::Data,
                         )
+                        .await?;
+                    manifest_list_writer
+                        .finish(snapshot_id, object_store)
                         .await?
                 };
 

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -474,7 +474,7 @@ impl Operation {
                 let snapshot_id = generate_snapshot_id();
 
                 let selected_manifest_location = manifest_list_writer
-                    .selected_manifest()
+                    .selected_data_manifest()
                     .map(|x| x.manifest_path.clone())
                     .ok_or(Error::NotFound("Selected manifest".to_owned()))?;
 

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -20,6 +20,7 @@ use iceberg_rust_spec::spec::{
 };
 use iceberg_rust_spec::table_metadata::FormatVersion;
 use iceberg_rust_spec::util::strip_prefix;
+use itertools::Either;
 use object_store::ObjectStore;
 use smallvec::SmallVec;
 use tokio::task::JoinHandle;
@@ -166,48 +167,36 @@ impl Operation {
 
                 // Write manifest files
                 // Split manifest file if limit is exceeded
-                if n_data_files != 0 {
-                    if n_data_splits == 0 {
-                        manifest_list_writer
-                            .append(
-                                new_datafile_iter,
-                                snapshot_id,
-                                object_store.clone(),
-                                Content::Data,
-                            )
-                            .await?;
-                    } else {
-                        manifest_list_writer
-                            .append_multiple(
-                                new_datafile_iter,
-                                snapshot_id,
-                                n_data_splits,
-                                object_store.clone(),
-                                Content::Data,
-                            )
-                            .await?;
-                    }
-                }
-                if n_delete_files != 0 {
-                    if n_delete_splits == 0 {
-                        manifest_list_writer
-                            .append(
-                                new_deletefile_iter,
-                                snapshot_id,
-                                object_store.clone(),
-                                Content::Deletes,
-                            )
-                            .await?;
-                    } else {
-                        manifest_list_writer
-                            .append_multiple(
-                                new_deletefile_iter,
-                                snapshot_id,
-                                n_delete_splits,
-                                object_store.clone(),
-                                Content::Deletes,
-                            )
-                            .await?;
+                for (content, files, n_files, n_splits) in [
+                    (
+                        Content::Data,
+                        Either::Left(new_datafile_iter),
+                        n_data_files,
+                        n_data_splits,
+                    ),
+                    (
+                        Content::Deletes,
+                        Either::Right(new_deletefile_iter),
+                        n_delete_files,
+                        n_delete_splits,
+                    ),
+                ] {
+                    if n_files != 0 {
+                        if n_splits == 0 {
+                            manifest_list_writer
+                                .append(files, snapshot_id, object_store.clone(), content)
+                                .await?;
+                        } else {
+                            manifest_list_writer
+                                .append_multiple(
+                                    files,
+                                    snapshot_id,
+                                    n_data_splits,
+                                    object_store.clone(),
+                                    content,
+                                )
+                                .await?;
+                        }
                     }
                 }
 

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -165,44 +165,52 @@ impl Operation {
                 // Write manifest files
                 // Split manifest file if limit is exceeded
                 let new_manifest_list_location = if n_splits == 0 {
-                    manifest_list_writer
-                        .append(
-                            new_datafile_iter,
-                            snapshot_id,
-                            object_store.clone(),
-                            Content::Data,
-                        )
-                        .await?;
-                    manifest_list_writer
-                        .append(
-                            new_delete_iter,
-                            snapshot_id,
-                            object_store.clone(),
-                            Content::Deletes,
-                        )
-                        .await?;
+                    if n_data_files != 0 {
+                        manifest_list_writer
+                            .append(
+                                new_datafile_iter,
+                                snapshot_id,
+                                object_store.clone(),
+                                Content::Data,
+                            )
+                            .await?;
+                    }
+                    if n_delete_files != 0 {
+                        manifest_list_writer
+                            .append(
+                                new_delete_iter,
+                                snapshot_id,
+                                object_store.clone(),
+                                Content::Deletes,
+                            )
+                            .await?;
+                    }
                     manifest_list_writer
                         .finish(snapshot_id, object_store)
                         .await?
                 } else {
-                    manifest_list_writer
-                        .append_multiple(
-                            new_datafile_iter,
-                            snapshot_id,
-                            n_splits,
-                            object_store.clone(),
-                            Content::Data,
-                        )
-                        .await?;
-                    manifest_list_writer
-                        .append_multiple(
-                            new_delete_iter,
-                            snapshot_id,
-                            n_splits,
-                            object_store.clone(),
-                            Content::Deletes,
-                        )
-                        .await?;
+                    if n_data_files != 0 {
+                        manifest_list_writer
+                            .append_multiple(
+                                new_datafile_iter,
+                                snapshot_id,
+                                n_splits,
+                                object_store.clone(),
+                                Content::Data,
+                            )
+                            .await?;
+                    }
+                    if n_delete_files != 0 {
+                        manifest_list_writer
+                            .append_multiple(
+                                new_delete_iter,
+                                snapshot_id,
+                                n_splits,
+                                object_store.clone(),
+                                Content::Deletes,
+                            )
+                            .await?;
+                    }
                     manifest_list_writer
                         .finish(snapshot_id, object_store)
                         .await?


### PR DESCRIPTION
This PR implements an alternative approach to solve #212.

It selects two manifest files, one for data and one for delete files. The aim is to limit the number of additional manifest files that have to be created.