### PR TITLE
fix: make version-hint.text compatible with other readers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,6 +2756,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3303,10 +3309,13 @@ dependencies = [
  "iceberg-rust-spec",
  "iceberg-sql-catalog",
  "itertools 0.14.0",
+ "lazy_static",
  "lru",
  "object_store",
  "parquet",
  "pin-project-lite",
+ "regex",
+ "rstest",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4776,6 +4785,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4912,6 +4927,36 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstest"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.104",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,12 @@ derive_builder = "0.20"
 futures = "0.3.31"
 getrandom = { version = "0.3.1", features = ["std"] }
 itertools = "0.14.0"
+lazy_static = "1.5.0"
 lru = "0.16.0"
 object_store = { version = "0.12", features = ["aws", "gcp"] }
 parquet = { version = "55", features = ["async", "object_store"] }
 pin-project-lite = "0.2"
+regex = "1.11.1"
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"

--- a/catalogs/iceberg-file-catalog/src/lib.rs
+++ b/catalogs/iceberg-file-catalog/src/lib.rs
@@ -885,10 +885,7 @@ pub mod tests {
             .await
             .unwrap();
 
-        assert_eq!(
-            std::str::from_utf8(&version_hint).unwrap(),
-            "s3://warehouse/tpch/lineitem/metadata/v1.metadata.json"
-        );
+        assert_eq!(std::str::from_utf8(&version_hint).unwrap(), "1");
     }
 
     #[tokio::test]

--- a/catalogs/iceberg-sql-catalog/src/lib.rs
+++ b/catalogs/iceberg-sql-catalog/src/lib.rs
@@ -781,9 +781,9 @@ pub mod tests {
     use testcontainers_modules::{localstack::LocalStack, postgres::Postgres};
     use tokio::time::sleep;
 
-    use std::{sync::Arc, time::Duration};
-
     use crate::SqlCatalog;
+    use iceberg_rust::object_store::store::version_hint_content;
+    use std::{sync::Arc, time::Duration};
 
     #[tokio::test]
     async fn test_create_update_drop_table() {
@@ -1004,8 +1004,10 @@ pub mod tests {
             .await
             .unwrap();
 
-        assert!(std::str::from_utf8(&version_hint)
-            .unwrap()
-            .ends_with(".metadata.json"));
+        let cache = iceberg_catalog.cache.read().unwrap();
+        let keys = cache.values().collect::<Vec<_>>();
+        let version = version_hint_content(&keys[0].clone().0);
+
+        assert_eq!(std::str::from_utf8(&version_hint).unwrap(), version);
     }
 }

--- a/datafusion_iceberg/Cargo.toml
+++ b/datafusion_iceberg/Cargo.toml
@@ -21,7 +21,7 @@ iceberg-rust = { path = "../iceberg-rust", version = "0.8.0" }
 itertools = { workspace = true }
 object_store = { workspace = true }
 pin-project-lite = "0.2.16"
-regex = "1.11.1"
+regex = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { version = "1.43", features = ["rt-multi-thread"] }

--- a/datafusion_iceberg/tests/equality_delete.rs
+++ b/datafusion_iceberg/tests/equality_delete.rs
@@ -204,18 +204,6 @@ pub async fn test_equality_delete() {
     ];
     assert_batches_eq!(expected, &batches);
 
-    let latest_version = table
-        .object_store()
-        .get(&object_store::path::Path::from(format!(
-            "{table_dir}/metadata/version-hint.text"
-        )))
-        .await
-        .unwrap()
-        .bytes()
-        .await
-        .unwrap();
-    let latest_version_str = std::str::from_utf8(&latest_version).unwrap();
-
     let conn = Connection::open_in_memory().unwrap();
     conn.execute("install iceberg", []).unwrap();
     conn.execute("load iceberg", []).unwrap();
@@ -223,7 +211,7 @@ pub async fn test_equality_delete() {
     let duckdb_batches: Vec<RecordBatch> = conn
         .prepare("select * from iceberg_scan(?) order by id")
         .unwrap()
-        .query_arrow([latest_version_str])
+        .query_arrow([table_dir])
         .unwrap()
         .collect();
     assert_batches_eq!(expected, &duckdb_batches);

--- a/iceberg-rust/Cargo.toml
+++ b/iceberg-rust/Cargo.toml
@@ -21,10 +21,12 @@ futures = { workspace = true }
 getrandom = { workspace = true }
 iceberg-rust-spec = { path = "../iceberg-rust-spec", version = "0.8.0" }
 itertools = { workspace = true }
+lazy_static = { workspace = true }
 lru = { workspace = true }
 object_store = { workspace = true }
 parquet = { workspace = true }
 pin-project-lite = { workspace = true }
+regex = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
@@ -39,6 +41,7 @@ uuid = { workspace = true }
 
 
 [dev-dependencies]
+rstest = "0.23.0"
 chrono = { workspace = true }
 iceberg-sql-catalog = { path = "../catalogs/iceberg-sql-catalog" }
 


### PR DESCRIPTION
Instead of storing the full path to the latest metadata file store only the relevant version string.

1. in case of the [file-system format](https://iceberg.apache.org/spec/#file-system-tables) that's just a single number `V` from `v<V>.metadata.json`. This works for both Spark and DuckDB.
2. in case of the [metastore](https://iceberg.apache.org/spec/#metastore-tables) format this is the number + the uuid, e.g. `00002-2ece07c9-4321-4926-8f05-f7eedce4d6d0` in `00002-2ece07c9-4321-4926-8f05-f7eedce4d6d0.metadata.json`, which DuckDb will recognize by default. 

Spark on the other hand doesn't accept that second format
```python
In [3]: df = spark.read.format("iceberg").load("/Users/gruuya/warehouse/test/orders")
25/08/07 12:34:43 WARN HadoopTableOperations: Error reading version hint file /Users/gruuya/warehouse/test/orders/metadata/version-hint.text
java.lang.NumberFormatException: For input string: "00002-2ece07c9-4321-4926-8f05-f7eedce4d6d0"
```
Even if the uuid part is trimmed I see ` org.apache.iceberg.exceptions.ValidationException: Metadata file for version 2 is missing`, suggesting Spark only tries to parse the provided hint as a number to be interpolated into the file-system format.