### PR TITLE
Refactor parquet writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,6 +2257,7 @@ dependencies = [
  "iceberg-rust",
  "iceberg-sql-catalog",
  "itertools 0.14.0",
+ "lru",
  "object_store",
  "pin-project-lite",
  "regex",

--- a/datafusion_iceberg/Cargo.toml
+++ b/datafusion_iceberg/Cargo.toml
@@ -19,6 +19,7 @@ derive_builder = { workspace = true }
 futures = { workspace = true }
 iceberg-rust = { path = "../iceberg-rust", version = "0.8.0" }
 itertools = { workspace = true }
+lru = { workspace = true }
 object_store = { workspace = true }
 pin-project-lite = "0.2.16"
 regex = "1.11.1"

--- a/datafusion_iceberg/src/error.rs
+++ b/datafusion_iceberg/src/error.rs
@@ -2,7 +2,7 @@
 Error type for iceberg
 */
 
-use datafusion::error::DataFusionError;
+use datafusion::{arrow::array::RecordBatch, error::DataFusionError};
 use iceberg_rust::error::Error as IcebergError;
 use thiserror::Error;
 
@@ -54,6 +54,15 @@ pub enum Error {
     /// parse int error
     #[error(transparent)]
     ParseInt(#[from] std::num::ParseIntError),
+    /// Tokio error
+    #[error(transparent)]
+    TokioSend(
+        #[from]
+        tokio::sync::mpsc::error::SendError<(
+            object_store::path::Path,
+            tokio::sync::mpsc::Receiver<RecordBatch>,
+        )>,
+    ),
     /// parse int error
     #[error(transparent)]
     DeriveBuilder(#[from] derive_builder::UninitializedFieldError),

--- a/datafusion_iceberg/src/table.rs
+++ b/datafusion_iceberg/src/table.rs
@@ -1207,10 +1207,84 @@ async fn row_count_demuxer(
         object_store::path::Path,
         mpsc::Receiver<datafusion::arrow::array::RecordBatch>,
     )>,
-    data: std::pin::Pin<Box<dyn RecordBatchStream + Send + 'static>>,
+    mut data: std::pin::Pin<Box<dyn RecordBatchStream + Send + 'static>>,
     context: Arc<TaskContext>,
 ) -> Result<(), DataFusionError> {
-    todo!()
+    let exec_options = &context.session_config().options().execution;
+
+    let max_rows_per_file = exec_options.soft_max_rows_per_output_file;
+    let max_buffered_batches = exec_options.max_buffered_batches_per_output_file;
+    let minimum_parallel_files = exec_options.minimum_parallel_output_files;
+    let mut part_idx = 0;
+    let write_id = rand::distributions::Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
+
+    let mut open_file_streams = Vec::with_capacity(minimum_parallel_files);
+
+    let mut next_send_steam = 0;
+    let mut row_counts = Vec::with_capacity(minimum_parallel_files);
+
+    while let Some(rb) = data.next().await.transpose()? {
+        // ensure we have at least minimum_parallel_files open
+        if open_file_streams.len() < minimum_parallel_files {
+            open_file_streams.push(create_new_file_stream(
+                &base_output_path,
+                &write_id,
+                part_idx,
+                &file_extension,
+                single_file_output,
+                max_buffered_batches,
+                &mut tx,
+            )?);
+            row_counts.push(0);
+            part_idx += 1;
+        } else if row_counts[next_send_steam] >= max_rows_per_file {
+            row_counts[next_send_steam] = 0;
+            open_file_streams[next_send_steam] = create_new_file_stream(
+                &base_output_path,
+                &write_id,
+                part_idx,
+                &file_extension,
+                single_file_output,
+                max_buffered_batches,
+                &mut tx,
+            )?;
+            part_idx += 1;
+        }
+        row_counts[next_send_steam] += rb.num_rows();
+        open_file_streams[next_send_steam]
+            .send(rb)
+            .await
+            .map_err(|_| {
+                DataFusionError::Execution("Error sending RecordBatch to file stream!".into())
+            })?;
+
+        next_send_steam = (next_send_steam + 1) % minimum_parallel_files;
+    }
+    Ok(())
+}
+
+/// Helper for row count demuxer
+fn create_new_file_stream(
+    base_output_path: &ListingTableUrl,
+    write_id: &str,
+    part_idx: usize,
+    file_extension: &str,
+    single_file_output: bool,
+    max_buffered_batches: usize,
+    tx: &mut mpsc::UnboundedSender<(Path, mpsc::Receiver<RecordBatch>)>,
+) -> Result<mpsc::Sender<RecordBatch>, DataFusionError> {
+    let file_path = generate_file_path(
+        base_output_path,
+        write_id,
+        part_idx,
+        file_extension,
+        single_file_output,
+    );
+    let (tx_file, rx_file) = mpsc::channel(max_buffered_batches / 2);
+    tx.send((file_path, rx_file)).map_err(|_| {
+        DataFusionError::Execution("Error sending RecordBatch to file stream!".into())
+    })?;
+    Ok(tx_file)
 }
 
 #[cfg(test)]

--- a/datafusion_iceberg/src/table.rs
+++ b/datafusion_iceberg/src/table.rs
@@ -1094,6 +1094,15 @@ pub async fn write_parquet_with_sink(
         ObjectStoreUrl::parse(bucket.to_string())?
     };
 
+    context.runtime_env().register_object_store(
+        &object_store_url
+            .as_str()
+            .try_into()
+            .map_err(Error::from)
+            .map_err(DataFusionIcebergError::from)?,
+        object_store.clone(),
+    );
+
     let config = FileSinkConfig {
         original_url: metadata.location.clone(),
         object_store_url,

--- a/iceberg-rust-spec/src/util.rs
+++ b/iceberg-rust-spec/src/util.rs
@@ -30,6 +30,7 @@ mod tests {
     #[test]
     fn strip_prefix_behaves_as_expected() {
         assert_eq!(strip_prefix("/a/b"), "/a/b");
+        assert_eq!(strip_prefix("memory:///a/b"), "/a/b");
         assert_eq!(strip_prefix("file:///a/b"), "/a/b");
         assert_eq!(strip_prefix("s3://bucket/a/b"), "/a/b");
         assert_eq!(strip_prefix("gs://bucket/a/b"), "/a/b");

--- a/iceberg-rust/src/arrow/partition.rs
+++ b/iceberg-rust/src/arrow/partition.rs
@@ -48,7 +48,7 @@ use super::transform::transform_arrow;
 /// * Required columns are missing from the record batch
 /// * Transformation operations fail
 /// * Data type conversions fail
-pub(crate) fn partition_record_batch<'a>(
+pub fn partition_record_batch<'a>(
     record_batch: &'a RecordBatch,
     partition_fields: &[BoundPartitionField<'_>],
 ) -> Result<impl Iterator<Item = Result<(Vec<Value>, RecordBatch), ArrowError>> + 'a, ArrowError> {


### PR DESCRIPTION
Use the datafusion ParquetSink to write parquet files for Iceberg tables.