### PR TITLE
allow space in object-store-url

### DIFF
--- a/catalogs/iceberg-file-catalog/src/lib.rs
+++ b/catalogs/iceberg-file-catalog/src/lib.rs
@@ -896,7 +896,10 @@ pub mod tests {
             .await
             .unwrap();
 
-        assert_eq!(std::str::from_utf8(&version_hint).unwrap(), "1");
+        assert_eq!(
+            std::str::from_utf8(&version_hint).unwrap(),
+            "s3://warehouse/tpch/lineitem/metadata/v1.metadata.json"
+        );
 
         let files = object_store.list(None).collect::<Vec<_>>().await;
 

--- a/datafusion_iceberg/src/table.rs
+++ b/datafusion_iceberg/src/table.rs
@@ -344,6 +344,7 @@ fn fake_object_store_url(table_location_url: &str) -> ObjectStoreUrl {
             .replace('-', "-2D")
             .replace('/', "-2F")
             .replace(':', "-3A")
+            .replace(' ', "-20")
     ))
     .expect("Invalid object store url.")
 }


### PR DESCRIPTION
Handle spaces in the fake object-store-url