### PR TITLE
Add support for Microsoft Azure Storage Blob in ObjectStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4148,6 +4148,7 @@ dependencies = [
  "futures",
  "http 1.3.1",
  "http-body-util",
+ "httparse",
  "humantime",
  "hyper 1.6.0",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ getrandom = { version = "0.3.1", features = ["std"] }
 itertools = "0.14.0"
 lazy_static = "1.5.0"
 lru = "0.16.0"
-object_store = { version = "0.12", features = ["aws", "gcp"] }
+object_store = { version = "0.12", features = ["aws", "gcp", "azure"] }
 murmur3 = { version = "0.5.2" }
 parquet = { version = "56", features = ["async", "object_store"] }
 pin-project-lite = "0.2"

--- a/catalogs/iceberg-file-catalog/src/lib.rs
+++ b/catalogs/iceberg-file-catalog/src/lib.rs
@@ -713,14 +713,19 @@ pub mod tests {
         let localstack_port = localstack.get_host_port_ipv4(4566).await.unwrap();
 
         let object_store = ObjectStoreBuilder::s3()
-            .with_config("aws_access_key_id".parse().unwrap(), "user")
-            .with_config("aws_secret_access_key".parse().unwrap(), "password")
+            .with_config("aws_access_key_id", "user")
+            .unwrap()
+            .with_config("aws_secret_access_key", "password")
+            .unwrap()
             .with_config(
-                "endpoint".parse().unwrap(),
+                "endpoint",
                 format!("http://{localstack_host}:{localstack_port}"),
             )
-            .with_config("region".parse().unwrap(), "us-east-1")
-            .with_config("allow_http".parse().unwrap(), "true");
+            .unwrap()
+            .with_config("region", "us-east-1")
+            .unwrap()
+            .with_config("allow_http", "true")
+            .unwrap();
         // let object_store = ObjectStoreBuilder::memory();
 
         let iceberg_catalog: Arc<dyn Catalog> = Arc::new(

--- a/catalogs/iceberg-glue-catalog/src/lib.rs
+++ b/catalogs/iceberg-glue-catalog/src/lib.rs
@@ -1063,14 +1063,19 @@ pub mod tests {
         let localstack_port = localstack.get_host_port_ipv4(4566).await.unwrap();
 
         let object_store = ObjectStoreBuilder::s3()
-            .with_config("aws_access_key_id".parse().unwrap(), "user")
-            .with_config("aws_secret_access_key".parse().unwrap(), "password")
+            .with_config("aws_access_key_id", "user")
+            .unwrap()
+            .with_config("aws_secret_access_key", "password")
+            .unwrap()
             .with_config(
-                "endpoint".parse().unwrap(),
+                "endpoint",
                 format!("http://{localstack_host}:{localstack_port}"),
             )
-            .with_config("region".parse().unwrap(), "us-east-1")
-            .with_config("allow_http".parse().unwrap(), "true");
+            .unwrap()
+            .with_config("region", "us-east-1")
+            .unwrap()
+            .with_config("allow_http", "true")
+            .unwrap();
 
         // let object_store = ObjectStoreBuilder::memory();
         let iceberg_catalog: Arc<dyn Catalog> =

--- a/catalogs/iceberg-rest-catalog/src/catalog.rs
+++ b/catalogs/iceberg-rest-catalog/src/catalog.rs
@@ -726,14 +726,19 @@ pub mod tests {
         let rest_port = rest.get_host_port_ipv4(8181).await.unwrap();
 
         let object_store = ObjectStoreBuilder::s3()
-            .with_config("aws_access_key_id".parse().unwrap(), "user")
-            .with_config("aws_secret_access_key".parse().unwrap(), "password")
+            .with_config("aws_access_key_id", "user")
+            .unwrap()
+            .with_config("aws_secret_access_key", "password")
+            .unwrap()
             .with_config(
-                "endpoint".parse().unwrap(),
+                "endpoint",
                 format!("http://{localstack_host}:{localstack_port}"),
             )
-            .with_config("region".parse().unwrap(), "us-east-1")
-            .with_config("allow_http".parse().unwrap(), "true");
+            .unwrap()
+            .with_config("region", "us-east-1")
+            .unwrap()
+            .with_config("allow_http", "true")
+            .unwrap();
 
         let iceberg_catalog = Arc::new(RestCatalog::new(
             None,

--- a/catalogs/iceberg-sql-catalog/src/lib.rs
+++ b/catalogs/iceberg-sql-catalog/src/lib.rs
@@ -829,14 +829,19 @@ pub mod tests {
         let localstack_port = localstack.get_host_port_ipv4(4566).await.unwrap();
 
         let object_store = ObjectStoreBuilder::s3()
-            .with_config("aws_access_key_id".parse().unwrap(), "user")
-            .with_config("aws_secret_access_key".parse().unwrap(), "password")
+            .with_config("aws_access_key_id", "user")
+            .unwrap()
+            .with_config("aws_secret_access_key", "password")
+            .unwrap()
             .with_config(
-                "endpoint".parse().unwrap(),
+                "endpoint",
                 format!("http://{localstack_host}:{localstack_port}"),
             )
-            .with_config("region".parse().unwrap(), "us-east-1")
-            .with_config("allow_http".parse().unwrap(), "true");
+            .unwrap()
+            .with_config("region", "us-east-1")
+            .unwrap()
+            .with_config("allow_http", "true")
+            .unwrap();
 
         let iceberg_catalog = Arc::new(
             SqlCatalog::new(

--- a/datafusion_iceberg/tests/empty_insert.rs
+++ b/datafusion_iceberg/tests/empty_insert.rs
@@ -44,14 +44,19 @@ pub async fn test_empty_insert() {
     let localstack_port = localstack.get_host_port_ipv4(4566).await.unwrap();
 
     let object_store = ObjectStoreBuilder::s3()
-        .with_config("aws_access_key_id".parse().unwrap(), "user")
-        .with_config("aws_secret_access_key".parse().unwrap(), "password")
+        .with_config("aws_access_key_id", "user")
+        .unwrap()
+        .with_config("aws_secret_access_key", "password")
+        .unwrap()
         .with_config(
-            "endpoint".parse().unwrap(),
+            "endpoint",
             format!("http://{localstack_host}:{localstack_port}"),
         )
-        .with_config("region".parse().unwrap(), "us-east-1")
-        .with_config("allow_http".parse().unwrap(), "true");
+        .unwrap()
+        .with_config("region", "us-east-1")
+        .unwrap()
+        .with_config("allow_http", "true")
+        .unwrap();
 
     let iceberg_catalog_list = Arc::new(
         SqlCatalogList::new("sqlite://", object_store.clone())

--- a/datafusion_iceberg/tests/integration_trino.rs
+++ b/datafusion_iceberg/tests/integration_trino.rs
@@ -185,14 +185,19 @@ async fn integration_trino_rest() {
         .unwrap();
 
     let object_store = ObjectStoreBuilder::s3()
-        .with_config("aws_access_key_id".parse().unwrap(), "user")
-        .with_config("aws_secret_access_key".parse().unwrap(), "password")
+        .with_config("aws_access_key_id", "user")
+        .unwrap()
+        .with_config("aws_secret_access_key", "password")
+        .unwrap()
         .with_config(
-            "endpoint".parse().unwrap(),
+            "endpoint",
             format!("http://{localstack_host}:{localstack_port}"),
         )
-        .with_config("region".parse().unwrap(), "us-east-1")
-        .with_config("allow_http".parse().unwrap(), "true");
+        .unwrap()
+        .with_config("region", "us-east-1")
+        .unwrap()
+        .with_config("allow_http", "true")
+        .unwrap();
 
     let catalog = Arc::new(RestCatalog::new(
         None,

--- a/iceberg-rust/src/object_store/mod.rs
+++ b/iceberg-rust/src/object_store/mod.rs
@@ -6,6 +6,7 @@ use std::{fmt::Display, path::Path, str::FromStr, sync::Arc};
 
 use object_store::{
     aws::{AmazonS3Builder, AmazonS3ConfigKey, S3CopyIfNotExists},
+    azure::{AzureConfigKey, MicrosoftAzureBuilder},
     gcp::{GoogleCloudStorageBuilder, GoogleConfigKey},
     local::LocalFileSystem,
     memory::InMemory,
@@ -24,6 +25,8 @@ pub enum Bucket<'s> {
     S3(&'s str),
     /// GCS bucket
     GCS(&'s str),
+    /// Azure container
+    Azure(&'s str),
     /// No bucket
     Local,
 }
@@ -33,13 +36,14 @@ impl Display for Bucket<'_> {
         match self {
             Bucket::S3(s) => write!(f, "s3://{s}"),
             Bucket::GCS(s) => write!(f, "gs://{s}"),
+            Bucket::Azure(s) => write!(f, "https://{s}"),
             Bucket::Local => write!(f, ""),
         }
     }
 }
 
 impl Bucket<'_> {
-    /// Get the bucket and coud provider from the location string
+    /// Get the bucket and cloud provider from the location string
     pub fn from_path(path: &str) -> Result<Bucket<'_>, Error> {
         if path.starts_with("s3://") || path.starts_with("s3a://") {
             let prefix = if path.starts_with("s3://") {
@@ -63,6 +67,17 @@ impl Bucket<'_> {
                 .next()
                 .map(Bucket::GCS)
                 .ok_or(Error::NotFound(format!("Bucket in path {path}")))
+        } else if path.starts_with("https://")
+            && (path.contains("dfs.core.windows.net")
+                || path.contains("blob.core.windows.net")
+                || path.contains("dfs.fabric.microsoft.com")
+                || path.contains("blob.fabric.microsoft.com"))
+        {
+            path.trim_start_matches("https://")
+                .split('/')
+                .nth(1)
+                .map(Bucket::Azure)
+                .ok_or(Error::NotFound(format!("Bucket in path {path}")))
         } else {
             Ok(Bucket::Local)
         }
@@ -72,6 +87,8 @@ impl Bucket<'_> {
 /// A wrapper for ObjectStore builders that can be used as a template to generate an ObjectStore given a particular bucket.
 #[derive(Debug, Clone)]
 pub enum ObjectStoreBuilder {
+    /// Microsoft Azure builder
+    Azure(Box<MicrosoftAzureBuilder>),
     /// AWS s3 builder
     S3(Box<AmazonS3Builder>),
     /// Google Cloud Storage builder
@@ -84,6 +101,8 @@ pub enum ObjectStoreBuilder {
 
 /// Configuration keys for [ObjectStoreBuilder]
 pub enum ConfigKey {
+    /// Configuration keys for Microsoft Azure
+    Azure(AzureConfigKey),
     /// Configuration keys for AWS S3
     AWS(AmazonS3ConfigKey),
     /// Configuration keys for GCS
@@ -93,6 +112,9 @@ pub enum ConfigKey {
 impl FromStr for ConfigKey {
     type Err = object_store::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(x) = s.parse() {
+            return Ok(ConfigKey::Azure(x));
+        };
         if let Ok(x) = s.parse() {
             return Ok(ConfigKey::AWS(x));
         };
@@ -106,6 +128,10 @@ impl FromStr for ConfigKey {
     }
 }
 impl ObjectStoreBuilder {
+    /// Create a new Microsoft Azure ObjectStoreBuilder
+    pub fn azure() -> Self {
+        ObjectStoreBuilder::Azure(Box::new(MicrosoftAzureBuilder::from_env()))
+    }
     /// Create new AWS S3 Object Store builder
     pub fn s3() -> Self {
         ObjectStoreBuilder::S3(Box::new(AmazonS3Builder::from_env()))
@@ -125,6 +151,9 @@ impl ObjectStoreBuilder {
     /// Set config value for builder
     pub fn with_config(self, key: ConfigKey, value: impl Into<String>) -> Self {
         match (self, key) {
+            (ObjectStoreBuilder::Azure(azure), ConfigKey::Azure(key)) => {
+                ObjectStoreBuilder::Azure(Box::new(azure.with_config(key, value)))
+            }
             (ObjectStoreBuilder::S3(aws), ConfigKey::AWS(key)) => {
                 ObjectStoreBuilder::S3(Box::new(aws.with_config(key, value)))
             }
@@ -137,6 +166,13 @@ impl ObjectStoreBuilder {
     /// Create objectstore from template
     pub fn build(&self, bucket: Bucket) -> Result<Arc<dyn ObjectStore>, Error> {
         match (bucket, self) {
+            (Bucket::Azure(bucket), Self::Azure(builder)) => Ok::<_, Error>(Arc::new(
+                (**builder)
+                    .clone()
+                    .with_container_name(bucket)
+                    .build()
+                    .map_err(Error::from)?,
+            )),
             (Bucket::S3(bucket), Self::S3(builder)) => Ok::<_, Error>(Arc::new(
                 (**builder)
                     .clone()
@@ -155,6 +191,109 @@ impl ObjectStoreBuilder {
             (Bucket::Local, Self::Filesystem(object_store)) => Ok(object_store.clone()),
             (Bucket::Local, Self::Memory(object_store)) => Ok(object_store.clone()),
             _ => Err(Error::NotSupported("Object store protocol".to_owned())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_path_s3() {
+        let bucket = Bucket::from_path("s3://my-bucket/path/to/file").unwrap();
+        match bucket {
+            Bucket::S3(name) => assert_eq!(name, "my-bucket"),
+            _ => panic!("Expected S3 bucket"),
+        }
+    }
+
+    #[test]
+    fn test_from_path_s3a() {
+        let bucket = Bucket::from_path("s3a://my-bucket/path/to/file").unwrap();
+        match bucket {
+            Bucket::S3(name) => assert_eq!(name, "my-bucket"),
+            _ => panic!("Expected S3 bucket"),
+        }
+    }
+
+    #[test]
+    fn test_from_path_gcs() {
+        let bucket = Bucket::from_path("gcs://my-bucket/path/to/file").unwrap();
+        match bucket {
+            Bucket::GCS(name) => assert_eq!(name, "my-bucket"),
+            _ => panic!("Expected GCS bucket"),
+        }
+    }
+
+    #[test]
+    fn test_from_path_gs() {
+        let bucket = Bucket::from_path("gs://my-bucket/path/to/file").unwrap();
+        match bucket {
+            Bucket::GCS(name) => assert_eq!(name, "my-bucket"),
+            _ => panic!("Expected GCS bucket"),
+        }
+    }
+
+    #[test]
+    fn test_from_path_azure_dfs() {
+        let bucket =
+            Bucket::from_path("https://mystorageaccount.dfs.core.windows.net/container/path")
+                .unwrap();
+        match bucket {
+            Bucket::Azure(name) => assert_eq!(name, "container"),
+            _ => panic!("Expected Azure bucket"),
+        }
+    }
+
+    #[test]
+    fn test_from_path_azure_blob() {
+        let bucket =
+            Bucket::from_path("https://mystorageaccount.blob.core.windows.net/container/path")
+                .unwrap();
+        match bucket {
+            Bucket::Azure(name) => assert_eq!(name, "container"),
+            _ => panic!("Expected Azure bucket"),
+        }
+    }
+
+    #[test]
+    fn test_from_path_azure_fabric_dfs() {
+        let bucket =
+            Bucket::from_path("https://mystorageaccount.dfs.fabric.microsoft.com/container/path")
+                .unwrap();
+        match bucket {
+            Bucket::Azure(name) => assert_eq!(name, "container"),
+            _ => panic!("Expected Azure bucket"),
+        }
+    }
+
+    #[test]
+    fn test_from_path_azure_fabric_blob() {
+        let bucket =
+            Bucket::from_path("https://mystorageaccount.blob.fabric.microsoft.com/container/path")
+                .unwrap();
+        match bucket {
+            Bucket::Azure(name) => assert_eq!(name, "container"),
+            _ => panic!("Expected Azure bucket"),
+        }
+    }
+
+    #[test]
+    fn test_from_path_local() {
+        let bucket = Bucket::from_path("/local/path/to/file").unwrap();
+        match bucket {
+            Bucket::Local => {}
+            _ => panic!("Expected Local bucket"),
+        }
+    }
+
+    #[test]
+    fn test_from_path_https_non_azure() {
+        let bucket = Bucket::from_path("https://example.com/path").unwrap();
+        match bucket {
+            Bucket::Local => {}
+            _ => panic!("Expected Local bucket"),
         }
     }
 }

--- a/iceberg-rust/src/object_store/mod.rs
+++ b/iceberg-rust/src/object_store/mod.rs
@@ -149,18 +149,31 @@ impl ObjectStoreBuilder {
         ObjectStoreBuilder::Memory(Arc::new(InMemory::new()))
     }
     /// Set config value for builder
-    pub fn with_config(self, key: ConfigKey, value: impl Into<String>) -> Self {
-        match (self, key) {
-            (ObjectStoreBuilder::Azure(azure), ConfigKey::Azure(key)) => {
-                ObjectStoreBuilder::Azure(Box::new(azure.with_config(key, value)))
+    pub fn with_config(
+        self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Result<Self, Error> {
+        match self {
+            ObjectStoreBuilder::Azure(azure) => {
+                let key: AzureConfigKey = key.into().parse()?;
+                Ok(ObjectStoreBuilder::Azure(Box::new(
+                    azure.with_config(key, value),
+                )))
             }
-            (ObjectStoreBuilder::S3(aws), ConfigKey::AWS(key)) => {
-                ObjectStoreBuilder::S3(Box::new(aws.with_config(key, value)))
+            ObjectStoreBuilder::S3(aws) => {
+                let key: AmazonS3ConfigKey = key.into().parse()?;
+                Ok(ObjectStoreBuilder::S3(Box::new(
+                    aws.with_config(key, value),
+                )))
             }
-            (ObjectStoreBuilder::GCS(gcs), ConfigKey::GCS(key)) => {
-                ObjectStoreBuilder::GCS(Box::new(gcs.with_config(key, value)))
+            ObjectStoreBuilder::GCS(gcs) => {
+                let key: GoogleConfigKey = key.into().parse()?;
+                Ok(ObjectStoreBuilder::GCS(Box::new(
+                    gcs.with_config(key, value),
+                )))
             }
-            (x, _) => x,
+            x => Ok(x),
         }
     }
     /// Create objectstore from template


### PR DESCRIPTION
Adds support for Microsoft Azure Blob Storage to the object store abstraction in the project. It introduces Azure as storage backend, updates configuration parsing and builder logic, and provides thorough tests for Azure bucket detection and configuration. The changes ensure Azure can be used alongside AWS S3 and Google Cloud Storage with similar APIs and configuration patterns.