### PR TITLE
Set default for missing key_metadata field

### DIFF
--- a/iceberg-rust-spec/src/spec/manifest_list.rs
+++ b/iceberg-rust-spec/src/spec/manifest_list.rs
@@ -515,6 +515,7 @@ pub fn manifest_list_schema_v1() -> &'static AvroSchema {
                         "null",
                         "bytes"
                     ],
+                    "default": null,
                     "field-id": 519
                 }
             ]
@@ -651,6 +652,7 @@ pub fn manifest_list_schema_v2() -> &'static AvroSchema {
                         "null",
                         "bytes"
                     ],
+                    "default": null,
                     "field-id": 519
                 }
             ]


### PR DESCRIPTION
If there is no optional column in the avro snap file, then without a default, there will be an error during deserialization.