### PR TITLE
fix: Change Azure parquet URI to `abfss://`

### DIFF
--- a/iceberg-rust-spec/src/util.rs
+++ b/iceberg-rust-spec/src/util.rs
@@ -35,5 +35,13 @@ mod tests {
         assert_eq!(strip_prefix("s3://bucket/a/b"), "/a/b");
         assert_eq!(strip_prefix("gs://bucket/a/b"), "/a/b");
         assert_eq!(strip_prefix("az://bucket/a/b"), "/a/b");
+        assert_eq!(
+            strip_prefix("abfss://container@account.dfs.core.windows.net/a/b"),
+            "/a/b"
+        );
+        assert_eq!(
+            strip_prefix("abfs://container@account.dfs.core.windows.net/a/b"),
+            "/a/b"
+        );
     }
 }

--- a/iceberg-rust/src/object_store/mod.rs
+++ b/iceberg-rust/src/object_store/mod.rs
@@ -68,7 +68,7 @@ impl Display for Bucket<'_> {
             } => {
                 write!(
                     f,
-                    "https://{account}.{endpoint_type}.core.windows.net/{container}"
+                    "abfss://{container}@{account}.{endpoint_type}.core.windows.net"
                 )
             }
             Bucket::Local => write!(f, ""),


### PR DESCRIPTION
@JanKaul One more change. Probably last one

With this, Spark connect was able to read the tables. 