### PR TITLE
Set corrent existing rows count

### DIFF
--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -381,10 +381,10 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         manifest.sequence_number = table_metadata.last_sequence_number + 1;
 
         manifest.existing_files_count = Some(
-            manifest.existing_files_count.unwrap_or(0) + manifest.added_files_count.unwrap_or(0)
+            manifest.existing_files_count.unwrap_or(0) + manifest.added_files_count.unwrap_or(0),
         );
         manifest.existing_rows_count = Some(
-            manifest.existing_rows_count.unwrap_or(0) + manifest.added_rows_count.unwrap_or(0)
+            manifest.existing_rows_count.unwrap_or(0) + manifest.added_rows_count.unwrap_or(0),
         );
 
         manifest.added_files_count = None;
@@ -444,7 +444,7 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
 
         let mut writer = AvroWriter::new(schema, Vec::new());
         let mut filtered_stats = FilteredManifestStats::default();
-        let mut existing_files  = 0i32;
+        let mut existing_files = 0i32;
         let mut existing_rows = 0i64;
 
         writer.add_user_metadata(

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -444,8 +444,6 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
 
         let mut writer = AvroWriter::new(schema, Vec::new());
         let mut filtered_stats = FilteredManifestStats::default();
-        let mut existing_files = 0i32;
-        let mut existing_rows = 0i64;
 
         writer.add_user_metadata(
             "format-version".to_string(),
@@ -510,8 +508,6 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
                 if entry.snapshot_id().is_none() {
                     *entry.snapshot_id_mut() = Some(manifest.added_snapshot_id);
                 }
-                existing_files += 1;
-                existing_rows += entry.data_file().record_count();
                 Some(to_value(entry).unwrap())
             } else {
                 if *entry.data_file().content() == Content::Data {
@@ -525,8 +521,14 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
 
         manifest.sequence_number = table_metadata.last_sequence_number + 1;
 
-        manifest.existing_files_count = Some(existing_files);
-        manifest.existing_rows_count = Some(existing_rows);
+        manifest.existing_files_count = Some(
+            manifest.existing_files_count.unwrap_or(0) + manifest.added_files_count.unwrap_or(0)
+                - filtered_stats.removed_data_files,
+        );
+        manifest.existing_rows_count = Some(
+            manifest.existing_rows_count.unwrap_or(0) + manifest.added_rows_count.unwrap_or(0)
+                - filtered_stats.removed_records,
+        );
 
         manifest.added_files_count = None;
         manifest.added_rows_count = None;


### PR DESCRIPTION
When we filter data files we should also adjust added and existing rows and files count.
Since we use filtered stats only for counting removed data files and rows.
Example,
We have 
```
added_files_count: 1
added_rows_count: 6001215
```
**for the case with whole file overwrite from_existing_with_filter returns**
```
  added_files_count: 0
  existing_files_count: 1
  added_rows_count: 6001215
```
**And then we call append new data file with applying filtered stats**
```
  added_files_count: 1
  existing_files_count: 1
  deleted_files_count: 1
  added_rows_count: 12002430
```
Related to https://github.com/JanKaul/iceberg-rust/issues/291
