### PR TITLE
Save filtered data files in separate manifest for compatability

### DIFF
--- a/iceberg-rust-spec/src/spec/manifest_list.rs
+++ b/iceberg-rust-spec/src/spec/manifest_list.rs
@@ -218,11 +218,11 @@ mod _serde {
                 min_sequence_number: value.min_sequence_number,
                 added_snapshot_id: value.added_snapshot_id,
                 added_files_count: value.added_files_count.unwrap(),
-                existing_files_count: value.existing_files_count.unwrap(),
-                deleted_files_count: value.deleted_files_count.unwrap(),
+                existing_files_count: value.existing_files_count.unwrap_or_default(),
+                deleted_files_count: value.deleted_files_count.unwrap_or_default(),
                 added_rows_count: value.added_rows_count.unwrap(),
-                existing_rows_count: value.existing_rows_count.unwrap(),
-                deleted_rows_count: value.deleted_rows_count.unwrap(),
+                existing_rows_count: value.existing_rows_count.unwrap_or_default(),
+                deleted_rows_count: value.deleted_rows_count.unwrap_or_default(),
                 partitions: value
                     .partitions
                     .map(|v| v.into_iter().map(Into::into).collect()),

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -386,7 +386,7 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
                 .filter_map(Result::ok),
         )?;
 
-        manifest.sequence_number = table_metadata.last_sequence_number + 1;
+        manifest.sequence_number = sequence_number;
         manifest.min_sequence_number = min_sequence_number;
 
         manifest.existing_files_count = Some(

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -369,8 +369,9 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
                 .ok()?;
 
             if *entry.status() != Status::Deleted {
-                *entry.status_mut() = Status::Existing;
+                return None;
             }
+            *entry.status_mut() = Status::Existing;
             if entry.sequence_number().is_none() {
                 *entry.sequence_number_mut() = Some(manifest.sequence_number);
             }
@@ -506,6 +507,10 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
                 .unwrap();
 
             // Skip deleted data files
+            if *entry.status() == Status::Deleted {
+                return None;
+            }
+
             if entry.sequence_number().is_none() {
                 *entry.sequence_number_mut() = Some(manifest.sequence_number);
             }
@@ -523,10 +528,7 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
                 filtered_stats.filtered_entries.push(entry);
                 None
             } else {
-                if *entry.status() != Status::Deleted {
-                    *entry.status_mut() = Status::Existing;
-                }
-
+                *entry.status_mut() = Status::Existing;
                 Some(to_value(entry).unwrap())
             }
         }))?;

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -160,11 +160,12 @@ pub(crate) struct ManifestWriter<'schema, 'metadata> {
     writer: AvroWriter<'schema, Vec<u8>>,
 }
 
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone)]
 pub(crate) struct FilteredManifestStats {
     pub removed_data_files: i32,
     pub removed_records: i64,
     pub removed_file_size_bytes: i64,
+    pub filtered_entries: Vec<ManifestEntry>,
 }
 
 impl FilteredManifestStats {
@@ -172,6 +173,7 @@ impl FilteredManifestStats {
         self.removed_file_size_bytes += stats.removed_file_size_bytes;
         self.removed_records += stats.removed_records;
         self.removed_data_files += stats.removed_data_files;
+        self.filtered_entries.extend(stats.filtered_entries);
     }
 }
 
@@ -361,6 +363,9 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             },
         )?;
 
+        let sequence_number = table_metadata.last_sequence_number + 1;
+        let mut min_sequence_number = sequence_number;
+
         writer.extend(
             manifest_reader
                 .map(|entry| {
@@ -368,7 +373,10 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
                         .map_err(|err| apache_avro::Error::DeserializeValue(err.to_string()))?;
                     *entry.status_mut() = Status::Existing;
                     if entry.sequence_number().is_none() {
-                        *entry.sequence_number_mut() = Some(manifest.sequence_number);
+                        *entry.sequence_number_mut() = Some(sequence_number);
+                    }
+                    if let Some(seq) = entry.sequence_number() {
+                        min_sequence_number = min_sequence_number.min(*seq);
                     }
                     if entry.snapshot_id().is_none() {
                         *entry.snapshot_id_mut() = Some(manifest.added_snapshot_id);
@@ -379,6 +387,7 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         )?;
 
         manifest.sequence_number = table_metadata.last_sequence_number + 1;
+        manifest.min_sequence_number = min_sequence_number;
 
         manifest.existing_files_count = Some(
             manifest.existing_files_count.unwrap_or(0) + manifest.added_files_count.unwrap_or(0),
@@ -496,30 +505,41 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             },
         )?;
 
+        let sequence_number = table_metadata.last_sequence_number + 1;
+        let mut min_sequence_number = sequence_number;
+
         writer.extend(manifest_reader.filter_map(|entry| {
             let mut entry = entry
                 .map_err(|err| apache_avro::Error::DeserializeValue(err.to_string()))
                 .unwrap();
-            if !filter.contains(entry.data_file().file_path()) {
-                *entry.status_mut() = Status::Existing;
-                if entry.sequence_number().is_none() {
-                    *entry.sequence_number_mut() = Some(manifest.sequence_number);
-                }
-                if entry.snapshot_id().is_none() {
-                    *entry.snapshot_id_mut() = Some(manifest.added_snapshot_id);
-                }
-                Some(to_value(entry).unwrap())
-            } else {
+
+            if entry.sequence_number().is_none() {
+                *entry.sequence_number_mut() = Some(sequence_number);
+            }
+            if entry.snapshot_id().is_none() {
+                *entry.snapshot_id_mut() = Some(manifest.added_snapshot_id);
+            }
+
+            if filter.contains(entry.data_file().file_path()) {
                 if *entry.data_file().content() == Content::Data {
                     filtered_stats.removed_records += entry.data_file().record_count();
                 }
                 filtered_stats.removed_file_size_bytes += entry.data_file().file_size_in_bytes();
                 filtered_stats.removed_data_files += 1;
+                *entry.status_mut() = Status::Deleted;
+                filtered_stats.filtered_entries.push(entry);
                 None
+            } else {
+                *entry.status_mut() = Status::Existing;
+                if let Some(seq) = entry.sequence_number() {
+                    min_sequence_number = min_sequence_number.min(*seq);
+                }
+                Some(to_value(entry).unwrap())
             }
         }))?;
 
-        manifest.sequence_number = table_metadata.last_sequence_number + 1;
+        manifest.sequence_number = sequence_number;
+        manifest.min_sequence_number = min_sequence_number;
 
         manifest.existing_files_count = Some(
             manifest.existing_files_count.unwrap_or(0) + manifest.added_files_count.unwrap_or(0)
@@ -565,6 +585,7 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
     pub(crate) fn append(&mut self, manifest_entry: ManifestEntry) -> Result<(), Error> {
         let mut added_rows_count = 0;
         let mut deleted_rows_count = 0;
+        let mut existing_rows_count = 0;
 
         if self.manifest.partitions.is_none() {
             self.manifest.partitions = Some(
@@ -582,16 +603,24 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             );
         }
 
+        let status = *manifest_entry.status();
         match manifest_entry.data_file().content() {
-            Content::Data => {
-                added_rows_count += manifest_entry.data_file().record_count();
-            }
+            Content::Data => match status {
+                Status::Added => {
+                    added_rows_count += manifest_entry.data_file().record_count();
+                }
+                Status::Existing => {
+                    existing_rows_count += manifest_entry.data_file().record_count();
+                }
+                Status::Deleted => {
+                    deleted_rows_count += manifest_entry.data_file().record_count();
+                }
+            },
             Content::EqualityDeletes => {
                 deleted_rows_count += manifest_entry.data_file().record_count();
             }
             _ => (),
         }
-        let status = *manifest_entry.status();
 
         update_partitions(
             self.manifest.partitions.as_mut().unwrap(),
@@ -718,23 +747,6 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
                 .await
         };
         Ok((self.manifest, future))
-    }
-
-    pub(crate) fn apply_filtered_stats(&mut self, filtered_stats: &FilteredManifestStats) {
-        let removed_files = filtered_stats.removed_data_files;
-        if removed_files > 0 {
-            self.manifest.deleted_files_count = match self.manifest.deleted_files_count {
-                Some(count) => Some(count + removed_files),
-                None => Some(removed_files),
-            };
-        }
-
-        if filtered_stats.removed_records > 0 {
-            self.manifest.deleted_rows_count = match self.manifest.deleted_rows_count {
-                Some(count) => Some(count + filtered_stats.removed_records),
-                None => Some(filtered_stats.removed_records),
-            };
-        }
     }
 }
 

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -368,7 +368,7 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
                 .map_err(|err| apache_avro::Error::DeserializeValue(err.to_string()))
                 .ok()?;
 
-            if *entry.status() != Status::Deleted {
+            if *entry.status() == Status::Deleted {
                 return None;
             }
             *entry.status_mut() = Status::Existing;
@@ -506,7 +506,6 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
                 .map_err(|err| apache_avro::Error::DeserializeValue(err.to_string()))
                 .unwrap();
 
-            // Skip deleted data files
             if *entry.status() == Status::Deleted {
                 return None;
             }

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -680,11 +680,14 @@ impl Operation {
                         branch.as_deref(),
                     )?;
 
+                let snapshot_id = generate_snapshot_id();
+
                 let mut filtered_stats = manifest_list_writer
                     .append_and_filter(
                         manifests_to_overwrite,
                         &files_to_overwrite,
                         object_store.clone(),
+                        snapshot_id,
                     )
                     .await?;
 
@@ -699,8 +702,6 @@ impl Operation {
                         .build()
                         .map_err(Error::from)
                 });
-
-                let snapshot_id = generate_snapshot_id();
 
                 let selected_manifest_location = manifest_list_writer
                     .selected_data_manifest()
@@ -747,27 +748,30 @@ impl Operation {
 
                 // Store separate manifest with filtered data files for compatability
                 if !filtered_stats.filtered_entries.is_empty() {
+                    let n_filtered_files = filtered_stats.filtered_entries.len();
                     let filtered_iter = filtered_stats.filtered_entries.clone().into_iter().map(Ok);
-                    if n_splits == 0 {
+                    let n_filtered_splits =
+                        manifest_list_writer.n_splits(n_filtered_files, ManifestListContent::Data);
+
+                    if n_filtered_splits == 0 {
                         manifest_list_writer
-                            .append_filtered(
+                            .append(
                                 filtered_iter,
                                 snapshot_id,
-                                None::<HashSet<String>>,
                                 object_store.clone(),
                                 ManifestListContent::Data,
                             )
                             .await?;
                     } else {
                         manifest_list_writer
-                            .append_multiple_filtered(
+                            .append_multiple_concurrently(
                                 filtered_iter,
                                 snapshot_id,
-                                n_splits,
-                                None::<HashSet<String>>,
+                                n_filtered_splits,
                                 object_store.clone(),
                                 ManifestListContent::Data,
                             )
+                            .await?
                             .await?;
                     };
                 }


### PR DESCRIPTION
- for overwrite operation we need to save filtered data files for compatability with other iceberg engines since they take into account all deteled data files and stats within current snapshot 
- Prevented deleted manifest entries from being re-marked as existing when reusing manifests during overwrite/merge operations, preserving prior deletions.
- **Spark** and **Snowflake** create additional manifest to track all deleted files for compatability
```Record 1:
  manifest_path: s3://...-m1.avro
  manifest_length: 7944
  partition_spec_id: 0
  content: 0
  sequence_number: 2
  min_sequence_number: 2
  added_snapshot_id: 8234522747398339109
  added_files_count: 1
  existing_files_count: 0
  deleted_files_count: 0
  added_rows_count: 6001215
  existing_rows_count: 0
  deleted_rows_count: 0
  partitions: []
  key_metadata: None

Record 2:
  manifest_path: s3://...-m0.avro
  manifest_length: 7942
  partition_spec_id: 0
  content: 0
  sequence_number: 2
  min_sequence_number: 2
  added_snapshot_id: 8234522747398339109
  added_files_count: 0
  existing_files_count: 0
  deleted_files_count: 1
  added_rows_count: 0
  existing_rows_count: 0
  deleted_rows_count: 6001215
  partitions: []
  key_metadata: None
```
- this mechanism can be also used in future to restore removed data