### PR TITLE
Add a check to ensure overwrites manifest actually exists in the snapshot on Overwrite operation

### DIFF
--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -669,7 +669,7 @@ impl Operation {
 
                 let data_files_iter = data_files.iter();
 
-                let manifests_to_overwrite_set: HashSet<String> =
+                let manifests_to_overwrite: HashSet<String> =
                     files_to_overwrite.keys().map(ToOwned::to_owned).collect();
 
                 let bytes = prefetch_manifest_list(Some(old_snapshot), &object_store)
@@ -680,27 +680,11 @@ impl Operation {
                     ManifestListWriter::from_existing_without_overwrites(
                         &bytes,
                         data_files_iter,
-                        &manifests_to_overwrite_set,
+                        &manifests_to_overwrite,
                         manifest_list_schema,
                         table_metadata,
                         branch.as_deref(),
                     )?;
-
-                let mut actual_manifests_to_overwrite_set: HashSet<String> = manifests_to_overwrite
-                    .iter()
-                    .map(|x| x.manifest_path.to_owned())
-                    .collect();
-
-                manifest_list_writer
-                    .selected_data_manifest()
-                    .iter()
-                    .for_each(|m| {
-                        actual_manifests_to_overwrite_set.insert(m.manifest_path.to_owned());
-                    });
-
-                if manifests_to_overwrite_set != actual_manifests_to_overwrite_set {
-                    return Err(Error::NotFound("Manifests to overwrite".to_owned()));
-                }
 
                 let mut filtered_stats = manifest_list_writer
                     .append_and_filter(

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -669,7 +669,7 @@ impl Operation {
 
                 let data_files_iter = data_files.iter();
 
-                let manifests_to_overwrite: HashSet<String> =
+                let manifests_to_overwrite_set: HashSet<String> =
                     files_to_overwrite.keys().map(ToOwned::to_owned).collect();
 
                 let bytes = prefetch_manifest_list(Some(old_snapshot), &object_store)
@@ -680,11 +680,27 @@ impl Operation {
                     ManifestListWriter::from_existing_without_overwrites(
                         &bytes,
                         data_files_iter,
-                        &manifests_to_overwrite,
+                        &manifests_to_overwrite_set,
                         manifest_list_schema,
                         table_metadata,
                         branch.as_deref(),
                     )?;
+
+                let mut actual_manifests_to_overwrite_set: HashSet<String> = manifests_to_overwrite
+                    .iter()
+                    .map(|x| x.manifest_path.to_owned())
+                    .collect();
+
+                manifest_list_writer
+                    .selected_data_manifest()
+                    .iter()
+                    .for_each(|m| {
+                        actual_manifests_to_overwrite_set.insert(m.manifest_path.to_owned());
+                    });
+
+                if manifests_to_overwrite_set != actual_manifests_to_overwrite_set {
+                    return Err(Error::NotFound("Manifests to overwrite".to_owned()));
+                }
 
                 let mut filtered_stats = manifest_list_writer
                     .append_and_filter(

--- a/iceberg-rust/tests/overwrite_test.rs
+++ b/iceberg-rust/tests/overwrite_test.rs
@@ -123,6 +123,22 @@ async fn test_table_transaction_overwrite() {
         .expect("Failed to create files_to_overwrite mapping");
 
     // 8. Use TableTransaction::overwrite to replace the us-east partition files
+    let mut files_to_overwrite_missing_manifest = files_to_overwrite.clone();
+    files_to_overwrite_missing_manifest.insert(
+        "missing_manifest.avro".to_owned(),
+        vec!["missing_data_file_01.parquet".to_owned()],
+    );
+
+    assert!(table
+        .new_transaction(None)
+        .overwrite(
+            overwrite_data_files.clone(),
+            files_to_overwrite_missing_manifest,
+        )
+        .commit()
+        .await
+        .is_err());
+
     table
         .new_transaction(None)
         .overwrite(overwrite_data_files, files_to_overwrite)


### PR DESCRIPTION
When I first tried to use the Overwrite operation while implementing a custom table compaction engine, I used it in a wrong way but just using filename and not path, for overwrites.
The operation succedded but obviously the outcome was wrong, and the table ended-up with duplicates.
This PR just add a small check to ensure overwrites files actually exists in the current snapshot before committing.