### PR TITLE
Add snapshot-log pruning to ExpireSnapshots operation

### DIFF
--- a/iceberg-rust/src/catalog/commit.rs
+++ b/iceberg-rust/src/catalog/commit.rs
@@ -513,6 +513,10 @@ pub fn apply_table_updates(
                 for id in snapshot_ids {
                     metadata.snapshots.remove(&id);
                 }
+
+                metadata
+                    .snapshot_log
+                    .retain(|e| metadata.snapshots.contains_key(&e.snapshot_id));
             }
             TableUpdate::RemoveSnapshotRef { ref_name } => {
                 metadata.refs.remove(&ref_name);


### PR DESCRIPTION
The `snapshot-log` metadata's field is never pruned and so grows indefinitely.
I just added a filtering step to `RemoveSnapshots` update  code to ensure `snapshot-log` contains only valid snapshots.