### PR TITLE
Rest catalog oauth client credentials

### DIFF
--- a/catalogs/iceberg-rest-catalog/src/catalog.rs
+++ b/catalogs/iceberg-rest-catalog/src/catalog.rs
@@ -2,8 +2,9 @@ use crate::{
     apis::{
         self,
         catalog_api_api::{self, NamespaceExistsError},
-        configuration::Configuration,
+        configuration::{self, Configuration},
     },
+    configuration_rewriter::ConfigurationRewriter,
     models::{self, StorageCredential},
 };
 use async_trait::async_trait;
@@ -46,7 +47,9 @@ use url::Url;
 pub struct RestCatalog {
     name: Option<String>,
     configuration: Configuration,
+    configuration_rewriter: Option<Arc<dyn ConfigurationRewriter + Sync + Send>>,
     default_object_store_builder: Option<ObjectStoreBuilder>,
+    ignore_storage_credentials: bool,
     cache: Arc<RwLock<HashMap<Identifier, Arc<dyn ObjectStore>>>>,
 }
 
@@ -54,14 +57,53 @@ impl RestCatalog {
     pub fn new(
         name: Option<&str>,
         configuration: Configuration,
+        configuration_rewriter: Option<Arc<dyn ConfigurationRewriter + Sync + Send>>,
         default_object_store_builder: Option<ObjectStoreBuilder>,
+        ignore_storage_credentials: bool,
     ) -> Self {
         RestCatalog {
             name: name.map(ToString::to_string),
             configuration,
             default_object_store_builder,
+            ignore_storage_credentials,
+            configuration_rewriter,
             cache: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    async fn get_configuration(&self) -> Result<Configuration, Error> {
+        match &self.configuration_rewriter {
+            None => Ok(self.configuration.clone()),
+            Some(rw) => rw.rewrite_configuration(self.configuration.clone()).await,
+        }
+    }
+
+    fn get_object_store(
+        &self,
+        response: &models::LoadTableResult,
+    ) -> Result<Arc<dyn ObjectStore>, Error> {
+        if self.ignore_storage_credentials {
+            return self
+                .default_object_store_builder
+                .as_ref()
+                .ok_or(Error::NotFound("Default object store".to_string()))
+                .and_then(|x| {
+                    let bucket = Bucket::from_path(&response.metadata.location)?;
+                    x.build(bucket)
+                });
+        }
+
+        object_store_from_response(&response)?
+            .ok_or(Error::NotFound("Object store credentials".to_string()))
+            .or_else(|_| {
+                self.default_object_store_builder
+                    .as_ref()
+                    .ok_or(Error::NotFound("Default object store".to_string()))
+                    .and_then(|x| {
+                        let bucket = Bucket::from_path(&response.metadata.location)?;
+                        x.build(bucket)
+                    })
+            })
     }
 }
 
@@ -77,8 +119,9 @@ impl Catalog for RestCatalog {
         namespace: &Namespace,
         properties: Option<HashMap<String, String>>,
     ) -> Result<HashMap<String, String>, Error> {
+        let configuration = self.get_configuration().await?;
         let response = catalog_api_api::create_namespace(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             models::CreateNamespaceRequest {
                 namespace: namespace.to_vec(),
@@ -91,8 +134,9 @@ impl Catalog for RestCatalog {
     }
     /// Drop a namespace in the catalog
     async fn drop_namespace(&self, namespace: &Namespace) -> Result<(), Error> {
+        let configuration = self.get_configuration().await?;
         catalog_api_api::drop_namespace(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &namespace.to_string(),
         )
@@ -105,8 +149,9 @@ impl Catalog for RestCatalog {
         &self,
         namespace: &Namespace,
     ) -> Result<HashMap<String, String>, Error> {
+        let configuration = self.get_configuration().await?;
         let response = catalog_api_api::load_namespace_metadata(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &namespace.to_string(),
         )
@@ -121,8 +166,9 @@ impl Catalog for RestCatalog {
         updates: Option<HashMap<String, String>>,
         removals: Option<Vec<String>>,
     ) -> Result<(), Error> {
+        let configuration = self.get_configuration().await?;
         catalog_api_api::update_properties(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &namespace.to_string(),
             models::UpdateNamespacePropertiesRequest { updates, removals },
@@ -133,8 +179,10 @@ impl Catalog for RestCatalog {
     }
     /// Check if a namespace exists
     async fn namespace_exists(&self, namespace: &Namespace) -> Result<bool, Error> {
+        let configuration = self.get_configuration().await?;
+
         match catalog_api_api::namespace_exists(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &namespace.to_string(),
         )
@@ -156,8 +204,9 @@ impl Catalog for RestCatalog {
     }
     /// Lists all tables in the given namespace.
     async fn list_tabulars(&self, namespace: &Namespace) -> Result<Vec<Identifier>, Error> {
+        let configuration = self.get_configuration().await?;
         let tables = catalog_api_api::list_tables(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &namespace.to_string(),
             None,
@@ -184,8 +233,9 @@ impl Catalog for RestCatalog {
     }
     /// Lists all namespaces in the catalog.
     async fn list_namespaces(&self, parent: Option<&str>) -> Result<Vec<Namespace>, Error> {
+        let configuration = self.get_configuration().await?;
         let namespaces = catalog_api_api::list_namespaces(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             None,
             None,
@@ -206,20 +256,25 @@ impl Catalog for RestCatalog {
     }
     /// Check if a table exists
     async fn tabular_exists(&self, identifier: &Identifier) -> Result<bool, Error> {
+        let configuration = self.get_configuration().await?;
+
         match catalog_api_api::view_exists(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &identifier.namespace().to_string(),
             identifier.name(),
         )
-        .or_else(|_| async move {
-            catalog_api_api::table_exists(
-                &self.configuration,
-                self.name.as_deref(),
-                &identifier.namespace().to_string(),
-                identifier.name(),
-            )
-            .await
+        .or_else(|_| {
+            let configuration = configuration.clone();
+            async move {
+                catalog_api_api::table_exists(
+                    &configuration,
+                    self.name.as_deref(),
+                    &identifier.namespace().to_string(),
+                    identifier.name(),
+                )
+                .await
+            }
         })
         .await
         .map_err(Into::<Error>::into)
@@ -231,8 +286,9 @@ impl Catalog for RestCatalog {
     }
     /// Drop a table and delete all data and metadata files.
     async fn drop_table(&self, identifier: &Identifier) -> Result<(), Error> {
+        let configuration = self.get_configuration().await?;
         catalog_api_api::drop_table(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &identifier.namespace().to_string(),
             identifier.name(),
@@ -243,8 +299,9 @@ impl Catalog for RestCatalog {
     }
     /// Drop a table and delete all data and metadata files.
     async fn drop_view(&self, identifier: &Identifier) -> Result<(), Error> {
+        let configuration = self.get_configuration().await?;
         catalog_api_api::drop_view(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &identifier.namespace().to_string(),
             identifier.name(),
@@ -254,8 +311,9 @@ impl Catalog for RestCatalog {
     }
     /// Drop a table and delete all data and metadata files.
     async fn drop_materialized_view(&self, identifier: &Identifier) -> Result<(), Error> {
+        let configuration = self.get_configuration().await?;
         catalog_api_api::drop_view(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &identifier.namespace().to_string(),
             identifier.name(),
@@ -265,9 +323,10 @@ impl Catalog for RestCatalog {
     }
     /// Load a table.
     async fn load_tabular(self: Arc<Self>, identifier: &Identifier) -> Result<Tabular, Error> {
+        let configuration = self.get_configuration().await?;
         // Load View/Matview metadata, is loaded as tabular to enable both possibilities. Must not be table metadata
         let tabular_metadata = catalog_api_api::load_view(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &identifier.namespace().to_string(),
             identifier.name(),
@@ -284,7 +343,7 @@ impl Catalog for RestCatalog {
             Err(apis::Error::ResponseError(content)) => {
                 if content.status == 404 {
                     let response = catalog_api_api::load_table(
-                        &self.configuration,
+                        &configuration,
                         self.name.as_deref(),
                         &identifier.namespace().to_string(),
                         identifier.name(),
@@ -294,17 +353,7 @@ impl Catalog for RestCatalog {
                     .await
                     .map_err(|_| Error::CatalogNotFound)?;
 
-                    let object_store = object_store_from_response(&response)?
-                        .ok_or(Error::NotFound("Object store credentials".to_string()))
-                        .or_else(|_| {
-                            self.default_object_store_builder
-                                .as_ref()
-                                .ok_or(Error::NotFound("Default object store".to_string()))
-                                .and_then(|x| {
-                                    let bucket = Bucket::from_path(&response.metadata.location)?;
-                                    x.build(bucket)
-                                })
-                        })?;
+                    let object_store = self.get_object_store(&response)?;
 
                     self.cache
                         .write()
@@ -337,8 +386,9 @@ impl Catalog for RestCatalog {
         identifier: Identifier,
         create_table: CreateTable,
     ) -> Result<Table, Error> {
+        let configuration = self.get_configuration().await?;
         let response = catalog_api_api::create_table(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &identifier.namespace().to_string(),
             create_table,
@@ -347,17 +397,7 @@ impl Catalog for RestCatalog {
         .map_err(Into::<Error>::into)
         .await?;
 
-        let object_store = object_store_from_response(&response)?
-            .ok_or(Error::NotFound("Object store credentials".to_string()))
-            .or_else(|_| {
-                self.default_object_store_builder
-                    .as_ref()
-                    .ok_or(Error::NotFound("Default object store".to_string()))
-                    .and_then(|x| {
-                        let bucket = Bucket::from_path(&response.metadata.location)?;
-                        x.build(bucket)
-                    })
-            })?;
+        let object_store = self.get_object_store(&response)?;
 
         self.cache
             .write()
@@ -371,9 +411,10 @@ impl Catalog for RestCatalog {
         self: Arc<Self>,
         commit: iceberg_rust::catalog::commit::CommitTable,
     ) -> Result<Table, Error> {
+        let configuration = self.get_configuration().await?;
         let identifier = commit.identifier.clone();
         let response = catalog_api_api::update_table(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &identifier.namespace().to_string(),
             identifier.name(),
@@ -396,8 +437,9 @@ impl Catalog for RestCatalog {
         identifier: Identifier,
         create_view: CreateView<Option<()>>,
     ) -> Result<View, Error> {
+        let configuration = self.get_configuration().await?;
         catalog_api_api::create_view(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &identifier.namespace().to_string(),
             create_view,
@@ -418,9 +460,10 @@ impl Catalog for RestCatalog {
         .await
     }
     async fn update_view(self: Arc<Self>, commit: CommitView<Option<()>>) -> Result<View, Error> {
+        let configuration = self.get_configuration().await?;
         let identifier = commit.identifier.clone();
         catalog_api_api::replace_view(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &identifier.namespace().to_string(),
             identifier.name(),
@@ -447,10 +490,11 @@ impl Catalog for RestCatalog {
         identifier: Identifier,
         create_view: CreateMaterializedView,
     ) -> Result<MaterializedView, Error> {
+        let configuration = self.get_configuration().await?;
         let (create_view, mut create_table) = create_view.into();
         create_table.name.clone_from(&create_view.name);
         catalog_api_api::create_table(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &identifier.namespace().to_string(),
             create_table,
@@ -459,7 +503,7 @@ impl Catalog for RestCatalog {
         .map_err(Into::<Error>::into)
         .await?;
         catalog_api_api::create_view(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &identifier.namespace().to_string(),
             create_view,
@@ -484,9 +528,10 @@ impl Catalog for RestCatalog {
         self: Arc<Self>,
         commit: CommitView<FullIdentifier>,
     ) -> Result<MaterializedView, Error> {
+        let configuration = self.get_configuration().await?;
         let identifier = commit.identifier.clone();
         catalog_api_api::replace_view(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &identifier.namespace().to_string(),
             identifier.name(),
@@ -515,30 +560,21 @@ impl Catalog for RestCatalog {
         identifier: Identifier,
         metadata_location: &str,
     ) -> Result<Table, Error> {
+        let configuration = self.get_configuration().await?;
         let request = models::RegisterTableRequest::new(
             identifier.name().to_owned(),
             metadata_location.to_owned(),
         );
 
         let response = catalog_api_api::register_table(
-            &self.configuration,
+            &configuration,
             self.name.as_deref(),
             &identifier.namespace().to_string(),
             request,
         )
         .map_err(Into::<Error>::into)
         .await?;
-        let object_store = object_store_from_response(&response)?
-            .ok_or(Error::NotFound("Object store credentials".to_string()))
-            .or_else(|_| {
-                self.default_object_store_builder
-                    .as_ref()
-                    .ok_or(Error::NotFound("Default object store".to_string()))
-                    .and_then(|x| {
-                        let bucket = Bucket::from_path(&response.metadata.location)?;
-                        x.build(bucket)
-                    })
-            })?;
+        let object_store = self.get_object_store(&response)?;
 
         Table::new(identifier.clone(), self, object_store, response.metadata).await
     }
@@ -547,17 +583,23 @@ impl Catalog for RestCatalog {
 #[derive(Debug, Clone)]
 pub struct RestCatalogList {
     configuration: Configuration,
+    configuration_rewriter: Option<Arc<dyn ConfigurationRewriter + Sync + Send>>,
     object_store_builder: Option<ObjectStoreBuilder>,
+    ignore_storage_credentials: bool,
 }
 
 impl RestCatalogList {
     pub fn new(
         configuration: Configuration,
+        configuration_rewriter: Option<Arc<dyn ConfigurationRewriter + Sync + Send>>,
         object_store_builder: Option<ObjectStoreBuilder>,
+        ignore_storage_credentials: bool,
     ) -> Self {
         Self {
             configuration,
+            configuration_rewriter,
             object_store_builder,
+            ignore_storage_credentials,
         }
     }
 }
@@ -568,7 +610,9 @@ impl CatalogList for RestCatalogList {
         Some(Arc::new(RestCatalog::new(
             Some(name),
             self.configuration.clone(),
+            self.configuration_rewriter.clone(),
             self.object_store_builder.clone(),
+            self.ignore_storage_credentials,
         )))
     }
     async fn list_catalogs(&self) -> Vec<String> {
@@ -580,19 +624,25 @@ impl CatalogList for RestCatalogList {
 pub struct RestNoPrefixCatalogList {
     name: String,
     configuration: Configuration,
+    configuration_rewriter: Option<Arc<dyn ConfigurationRewriter + Sync + Send>>,
     object_store_builder: Option<ObjectStoreBuilder>,
+    ignore_storage_credentials: bool,
 }
 
 impl RestNoPrefixCatalogList {
     pub fn new(
         name: &str,
         configuration: Configuration,
+        configuration_rewriter: Option<Arc<dyn ConfigurationRewriter + Sync + Send>>,
         object_store_builder: Option<ObjectStoreBuilder>,
+        ignore_storage_credentials: bool,
     ) -> Self {
         Self {
             name: name.to_owned(),
             configuration,
+            configuration_rewriter,
             object_store_builder,
+            ignore_storage_credentials,
         }
     }
 }
@@ -604,7 +654,9 @@ impl CatalogList for RestNoPrefixCatalogList {
             Some(Arc::new(RestCatalog::new(
                 None,
                 self.configuration.clone(),
+                self.configuration_rewriter.clone(),
                 self.object_store_builder.clone(),
+                self.ignore_storage_credentials,
             )))
         } else {
             None
@@ -748,7 +800,9 @@ pub mod tests {
         let iceberg_catalog = Arc::new(RestCatalog::new(
             None,
             configuration(&format!("http://{rest_host}:{rest_port}")),
+            None,
             Some(object_store),
+            false,
         ));
 
         iceberg_catalog

--- a/catalogs/iceberg-rest-catalog/src/configuration_rewriter.rs
+++ b/catalogs/iceberg-rest-catalog/src/configuration_rewriter.rs
@@ -1,0 +1,14 @@
+use crate::apis::configuration::Configuration;
+use async_trait::async_trait;
+use iceberg_rust::error::Error;
+
+#[async_trait]
+pub trait ConfigurationRewriter {
+    async fn rewrite_configuration(&self, conf: Configuration) -> Result<Configuration, Error>;
+}
+
+impl std::fmt::Debug for dyn ConfigurationRewriter + Sync + Send {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}

--- a/catalogs/iceberg-rest-catalog/src/lib.rs
+++ b/catalogs/iceberg-rest-catalog/src/lib.rs
@@ -12,6 +12,8 @@ extern crate url;
 #[allow(clippy::all)]
 pub mod apis;
 pub mod catalog;
+pub mod configuration_rewriter;
 pub mod error;
 #[allow(clippy::all)]
 pub mod models;
+pub mod oauth2_client_credentials;

--- a/catalogs/iceberg-rest-catalog/src/oauth2_client_credentials.rs
+++ b/catalogs/iceberg-rest-catalog/src/oauth2_client_credentials.rs
@@ -1,0 +1,117 @@
+use super::configuration_rewriter::ConfigurationRewriter;
+use crate::apis::configuration;
+use crate::apis::configuration::Configuration;
+use async_trait::async_trait;
+use iceberg_rust::error::Error;
+use reqwest;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime};
+
+#[derive(Debug, Clone)]
+struct AccessToken {
+    token: String,
+    refresh_before: SystemTime,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct OAuth2ClientCredentials {
+    pub server_uri: String,
+    pub client_id: String,
+    pub client_secret: String,
+    pub audience: Option<String>,
+    pub scope: Option<String>,
+
+    access_token: Arc<Mutex<Option<AccessToken>>>,
+}
+
+impl OAuth2ClientCredentials {
+    pub fn new(
+        server_uri: String,
+        client_id: String,
+        client_secret: String,
+        audience: Option<String>,
+        scope: Option<String>,
+    ) -> Self {
+        OAuth2ClientCredentials {
+            server_uri,
+            client_id,
+            client_secret,
+            audience,
+            scope,
+            access_token: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    async fn fetch_token(&self) -> Result<AccessToken, Error> {
+        let client = reqwest::Client::new();
+        let mut req_builder = client.request(reqwest::Method::POST, &self.server_uri);
+        let mut body: std::collections::HashMap<&str, String> = std::collections::HashMap::new();
+        body.insert("grant_type", "client_credentials".to_owned());
+        body.insert("client_id", self.client_id.to_owned());
+        body.insert("client_secret", self.client_secret.to_owned());
+
+        if let Some(s) = &self.audience {
+            body.insert("audience", s.to_owned());
+        }
+
+        if let Some(s) = &self.scope {
+            body.insert("scope", s.to_owned());
+        }
+
+        req_builder = req_builder.form(&body);
+
+        let req = req_builder
+            .build()
+            .map_err(|e| Error::External(Box::new(e)))?;
+
+        let resp = client
+            .execute(req)
+            .await
+            .map_err(|e| Error::External(Box::new(e)))?
+            .error_for_status()
+            .map_err(|e| Error::External(Box::new(e)))?;
+
+        let content = resp
+            .text()
+            .await
+            .map_err(|e| Error::External(Box::new(e)))?;
+
+        let token_resp: TokenResponse = serde_json::from_str(&content)?;
+
+        Ok(AccessToken {
+            token: token_resp.access_token,
+            refresh_before: SystemTime::now()
+                .checked_add(Duration::from_secs((token_resp.expires_in * 70) / 100))
+                .unwrap(),
+        })
+    }
+}
+
+#[async_trait]
+impl ConfigurationRewriter for OAuth2ClientCredentials {
+    async fn rewrite_configuration(&self, mut conf: Configuration) -> Result<Configuration, Error> {
+        {
+            let access_token = self.access_token.lock().unwrap();
+
+            if let Some(s) = (*access_token).as_ref() {
+                if s.refresh_before > SystemTime::now() {
+                    conf.oauth_access_token = Some(s.token.clone());
+                    return Ok(conf);
+                }
+            }
+        }
+
+        let token = self.fetch_token().await?;
+        conf.oauth_access_token = Some(token.token.clone());
+        *self.access_token.lock().unwrap() = Some(token);
+
+        Ok(conf)
+    }
+}

--- a/iceberg-rust-spec/src/spec/manifest_list.rs
+++ b/iceberg-rust-spec/src/spec/manifest_list.rs
@@ -217,12 +217,12 @@ mod _serde {
                 sequence_number: value.sequence_number,
                 min_sequence_number: value.min_sequence_number,
                 added_snapshot_id: value.added_snapshot_id,
-                added_files_count: value.added_files_count.unwrap(),
-                existing_files_count: value.existing_files_count.unwrap(),
-                deleted_files_count: value.deleted_files_count.unwrap(),
-                added_rows_count: value.added_rows_count.unwrap(),
-                existing_rows_count: value.existing_rows_count.unwrap(),
-                deleted_rows_count: value.deleted_rows_count.unwrap(),
+                added_files_count: value.added_files_count.unwrap_or_default(),
+                existing_files_count: value.existing_files_count.unwrap_or_default(),
+                deleted_files_count: value.deleted_files_count.unwrap_or_default(),
+                added_rows_count: value.added_rows_count.unwrap_or_default(),
+                existing_rows_count: value.existing_rows_count.unwrap_or_default(),
+                deleted_rows_count: value.deleted_rows_count.unwrap_or_default(),
                 partitions: value
                     .partitions
                     .map(|v| v.into_iter().map(Into::into).collect()),

--- a/iceberg-rust/src/catalog/commit.rs
+++ b/iceberg-rust/src/catalog/commit.rs
@@ -513,6 +513,10 @@ pub fn apply_table_updates(
                 for id in snapshot_ids {
                     metadata.snapshots.remove(&id);
                 }
+
+                metadata
+                    .snapshot_log
+                    .retain(|e| metadata.snapshots.contains_key(&e.snapshot_id));
             }
             TableUpdate::RemoveSnapshotRef { ref_name } => {
                 metadata.refs.remove(&ref_name);

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -1316,7 +1316,12 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             removed_stats.removed_data_files += filtered_stats.removed_data_files;
             removed_stats.removed_records += filtered_stats.removed_records;
             removed_stats.removed_file_size_bytes += filtered_stats.removed_file_size_bytes;
-            self.writer.append_ser(manifest)?;
+
+            if manifest.added_files_count.unwrap_or(0) > 0
+                || manifest.existing_files_count.unwrap_or(0) > 0
+            {
+                self.writer.append_ser(manifest)?;
+            }
         }
         Ok(removed_stats)
     }

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -669,7 +669,7 @@ impl Operation {
 
                 let data_files_iter = data_files.iter();
 
-                let manifests_to_overwrite: HashSet<String> =
+                let manifests_to_overwrite_set: HashSet<String> =
                     files_to_overwrite.keys().map(ToOwned::to_owned).collect();
 
                 let bytes = prefetch_manifest_list(Some(old_snapshot), &object_store)
@@ -680,11 +680,27 @@ impl Operation {
                     ManifestListWriter::from_existing_without_overwrites(
                         &bytes,
                         data_files_iter,
-                        &manifests_to_overwrite,
+                        &manifests_to_overwrite_set,
                         manifest_list_schema,
                         table_metadata,
                         branch.as_deref(),
                     )?;
+
+                let mut actual_manifests_to_overwrite_set: HashSet<String> = manifests_to_overwrite
+                    .iter()
+                    .map(|x| x.manifest_path.to_owned())
+                    .collect();
+
+                manifest_list_writer
+                    .selected_data_manifest()
+                    .iter()
+                    .for_each(|m| {
+                        actual_manifests_to_overwrite_set.insert(m.manifest_path.to_owned());
+                    });
+
+                if manifests_to_overwrite_set != actual_manifests_to_overwrite_set {
+                    return Err(Error::NotFound("Manifests to overwrite".to_owned()));
+                }
 
                 let mut filtered_stats = manifest_list_writer
                     .append_and_filter(


### PR DESCRIPTION
This PR started when I tried to use the library to interact with an auth-enabled Lakekeeper instance.
For this to work, the catalog client needs to get (and refresh) an access token from an Oauth2 server (not the catalog server).

As I did not want to touch the generated code, I decided to add an abstraction that would allow to implement `rewrites` to the `Configuration` object passed to the generated code.
The client credentials flow has been implemented as a `Configuration` rewriter.

I also add a flag to disabled getting `storage_credentials` from the catalog server as it doers not work in some non-AWS environments.
