### PR TITLE
chore: add dependabot config for weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
Adds Dependabot configuration to automatically keep dependencies up-to-date.

## Changes
- Configure weekly Rust dependency updates (grouped into single PR)
- Configure weekly GitHub Actions updates

## Benefits
- Automated dependency updates
- Improved security with latest patches
- Reduced manual maintenance overhead