### PR TITLE
Databricks Unity Catalog support and bug fixes

### DIFF
--- a/catalogs/iceberg-rest-catalog/src/apis/fetch.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/fetch.rs
@@ -18,14 +18,7 @@ where
     T: for<'a> serde::Deserialize<'a>,
     E: for<'a> serde::Deserialize<'a>,
 {
-    let uri_base = match prefix {
-        Some(prefix) => format!(
-            "{}/v1/{prefix}/",
-            configuration.base_path,
-            prefix = crate::apis::urlencode(prefix)
-        ),
-        None => format!("{}/v1/", configuration.base_path,),
-    };
+    let uri_base = build_uri_base(configuration, prefix);
     let client = &configuration.client;
 
     let uri = uri_base + uri_str;
@@ -103,14 +96,7 @@ where
     R: serde::Serialize + ?Sized,
     E: for<'a> serde::Deserialize<'a>,
 {
-    let uri_base = match prefix {
-        Some(prefix) => format!(
-            "{}/v1/{prefix}/",
-            configuration.base_path,
-            prefix = crate::apis::urlencode(prefix)
-        ),
-        None => format!("{}/v1/", configuration.base_path,),
-    };
+    let uri_base = build_uri_base(configuration, prefix);
     let client = &configuration.client;
 
     let uri = uri_base + uri_str;
@@ -172,5 +158,26 @@ where
             entity,
         };
         Err(Error::ResponseError(error))
+    }
+}
+
+/// Build the base URI for REST API calls with proper prefix encoding
+fn build_uri_base(configuration: &configuration::Configuration, prefix: Option<&str>) -> String {
+    match prefix {
+        Some(prefix) => {
+            // Split prefix by '/' and URL-encode each segment individually
+            // This allows paths like "catalogs/warehouse_name" while still protecting
+            // against path traversal attacks (e.g., "../../../etc")
+            let encoded_segments: Vec<String> = prefix
+                .split('/')
+                .map(|segment| crate::apis::urlencode(segment))
+                .collect();
+            format!(
+                "{}/v1/{}/",
+                configuration.base_path,
+                encoded_segments.join("/")
+            )
+        }
+        None => format!("{}/v1/", configuration.base_path),
     }
 }

--- a/catalogs/iceberg-rest-catalog/src/catalog.rs
+++ b/catalogs/iceberg-rest-catalog/src/catalog.rs
@@ -215,7 +215,10 @@ impl Catalog for RestCatalog {
         .await
         .map_err(Into::<Error>::into)?;
         let tables = tables.identifiers.unwrap_or(Vec::new()).into_iter();
-        let views = catalog_api_api::list_views(
+
+        // Try to list views, but handle 404 gracefully (some catalogs like Databricks Unity Catalog
+        // don't implement the views endpoint yet)
+        let views = match catalog_api_api::list_views(
             &self.configuration,
             self.name.as_deref(),
             &namespace.to_string(),
@@ -223,13 +226,22 @@ impl Catalog for RestCatalog {
             None,
         )
         .await
-        .map_err(Into::<Error>::into)?;
-        Ok(views
-            .identifiers
-            .unwrap_or(Vec::new())
-            .into_iter()
-            .chain(tables)
-            .collect())
+        {
+            Ok(views) => views.identifiers.unwrap_or(Vec::new()),
+            Err(err) => {
+                if let apis::Error::ResponseError(ref response_err) = err {
+                    if response_err.status.as_u16() == 404 {
+                        Vec::new()
+                    } else {
+                        return Err(err.into());
+                    }
+                } else {
+                    return Err(err.into());
+                }
+            }
+        };
+
+        Ok(views.into_iter().chain(tables).collect())
     }
     /// Lists all namespaces in the catalog.
     async fn list_namespaces(&self, parent: Option<&str>) -> Result<Vec<Namespace>, Error> {
@@ -671,7 +683,7 @@ fn object_store_from_response(
     response: &models::LoadTableResult,
 ) -> Result<Option<Arc<dyn ObjectStore>>, Error> {
     let config = match (&response.storage_credentials, &response.config) {
-        (Some(credentials), Some(config)) => {
+        (Some(credentials), Some(config)) if !credentials.is_empty() => {
             // Enrich credentials with other options that might only be found in the config (e.g.
             // a custom endpoint)
             let mut options = credentials[0].config.clone();
@@ -679,7 +691,7 @@ fn object_store_from_response(
             options
         }
         (Some(credentials), None) => credentials[0].config.clone(),
-        (None, Some(config)) => config.clone(),
+        (_, Some(config)) => config.clone(),
         (None, None) => return Ok(None),
     };
 

--- a/iceberg-rust/src/arrow/write.rs
+++ b/iceberg-rust/src/arrow/write.rs
@@ -560,7 +560,13 @@ pub fn generate_file_path(data_location: &str, partition_path: Option<String>) -
             + "/"
     });
 
-    strip_prefix(data_location) + &path + &Uuid::now_v1(&rand).to_string() + ".parquet"
+    let base = strip_prefix(data_location);
+    let separator = if base.ends_with('/') || path.starts_with('/') {
+        ""
+    } else {
+        "/"
+    };
+    base + separator + &path + &Uuid::now_v1(&rand).to_string() + ".parquet"
 }
 
 /// Calculates the approximate size in bytes of an Arrow record batch.


### PR DESCRIPTION
This PR adds support for Databricks Unity Catalog and fixes several issues in the REST catalog implementation.

### 1. Support multi-segment prefixes in REST API calls

Enable REST catalogs to use hierarchical prefix patterns like `catalogs/warehouse_name` by encoding each path segment individually instead of encoding the entire prefix string.

**Before:** `catalogs/warehouse` → `catalogs%2Fwarehouse` (404 errors)  
**After:** `catalogs/warehouse` → `/catalogs/warehouse` (proper path segments)

This is required by Databricks Unity Catalog and other REST catalog implementations that return custom prefixes in their `/v1/config` response.

Note: This is more like a workaround. It would be better instead to check the response returned by the catalog and extract the prefix from there. PyIceberg does like this. 

### 2. Handle missing views endpoint and empty storage credentials

- **Views endpoint:** Databricks unity catalog don't implement the views endpoint yet. Now treats 404 responses as an empty view list instead of failing.
- **Empty credentials:** Added check for empty `storage_credentials` vector to prevent index out of bounds panic when catalogs return an empty array.

### 3. Fix missing path separator in Parquet file paths

Fixed path construction in `generate_file_path()` that was missing a separator between the data location and filename UUID.

**Before:** `tables/{table-uuid}{file-uuid}.parquet`  
**After:** `tables/{table-uuid}/{file-uuid}.parquet`

Adds logic to insert `/` when neither the base path ends with `/` nor the partition path starts with `/`.
