### PR TITLE
fix: make value lookup skip nested fields

### DIFF
--- a/iceberg-rust-spec/src/error.rs
+++ b/iceberg-rust-spec/src/error.rs
@@ -13,9 +13,6 @@ pub enum Error {
     /// Type error
     #[error("Value {0} doesn't have the {1} type.")]
     Type(String, String),
-    /// Schema error
-    #[error("Column {0} not in schema {1}.")]
-    ColumnNotInSchema(String, String),
     /// Conversion error
     #[error("Failed to convert {0} to {1}.")]
     Conversion(String, String),

--- a/iceberg-rust-spec/src/spec/manifest.rs
+++ b/iceberg-rust-spec/src/spec/manifest.rs
@@ -482,28 +482,17 @@ impl AvroMap<ByteBuf> {
     /// * `schema` - The struct type schema used to determine the correct type for each value
     ///
     /// # Returns
-    /// * `Result<HashMap<i32, Value>, Error>` - A map of field IDs to their typed values, or an error if conversion fails
+    /// * `Result<HashMap<i32, Value>, Error>` - A map of field IDs to their typed values, or an error if conversion fails.
+    ///   Field IDs not found in the top-level schema (e.g. nested struct fields) are skipped,
+    ///   since bounds are optional pruning statistics that are safe to discard.
     fn into_value_map(self, schema: &StructType) -> Result<HashMap<i32, Value>, Error> {
-        Ok(HashMap::from_iter(
-            self.0
-                .into_iter()
-                .map(|(k, v)| {
-                    Ok((
-                        k,
-                        Value::try_from_bytes(
-                            &v,
-                            &schema
-                                .get(k as usize)
-                                .ok_or(Error::ColumnNotInSchema(
-                                    k.to_string(),
-                                    format!("{schema:?}"),
-                                ))?
-                                .field_type,
-                        )?,
-                    ))
-                })
-                .collect::<Result<Vec<_>, Error>>()?,
-        ))
+        self.0
+            .into_iter()
+            .filter_map(|(k, v)| {
+                let field = schema.get(k as usize)?;
+                Some(Value::try_from_bytes(&v, &field.field_type).map(|val| (k, val)))
+            })
+            .collect()
     }
 }
 

--- a/iceberg-rust/src/table/mod.rs
+++ b/iceberg-rust/src/table/mod.rs
@@ -354,7 +354,7 @@ async fn datafiles(
         reader.filter_map(move |x| {
             let mut x = match x {
                 Ok(entry) => entry,
-                Err(_) => return None,
+                Err(err) => return Some(Err(err)),
             };
 
             let sequence_number = if let Some(sequence_number) = x.sequence_number() {


### PR DESCRIPTION
We noticed that selects were returning zero rows for Iceberg tables with nested columns created via pyspark.

The problem is two-fold:
- (py)spark will dump nested column lower/upper bounds to the manifest files, but when creating the `Value`s map from the avro file this crate uses the top-level schema, so it errors out on nested fields
- datafiles function will silently swallow any parsing issues in the manifest, and consequently the query goes through without warning, but it effectively has no manifests involved in the table state (hence 0 rows in all selects)

This PR fixes both:
- bubble up any errors encountered when parsing the manifests
- skip upper/lower bound values for fields that are not in the top-level schema