### PR TITLE
fix: accept legacy Athena field names in manifest list parsing

### DIFF
--- a/iceberg-rust-spec/src/spec/manifest_list.rs
+++ b/iceberg-rust-spec/src/spec/manifest_list.rs
@@ -134,10 +134,13 @@ mod _serde {
         /// ID of the snapshot where the manifest file was added
         pub added_snapshot_id: i64,
         /// Number of entries in the manifest that have status ADDED (1)
+        #[serde(alias = "added_data_files_count")]
         pub added_files_count: i32,
         /// Number of entries in the manifest that have status EXISTING (0)
+        #[serde(alias = "existing_data_files_count")]
         pub existing_files_count: i32,
         /// Number of entries in the manifest that have status DELETED (2)
+        #[serde(alias = "deleted_data_files_count")]
         pub deleted_files_count: i32,
         /// Number of rows in all of files in the manifest that have status ADDED
         pub added_rows_count: i64,
@@ -170,10 +173,13 @@ mod _serde {
         /// ID of the snapshot where the manifest file was added
         pub added_snapshot_id: i64,
         /// Number of entries in the manifest that have status ADDED (1), when null this is assumed to be non-zero
+        #[serde(alias = "added_data_files_count")]
         pub added_files_count: i32,
         /// Number of entries in the manifest that have status EXISTING (0), when null this is assumed to be non-zero
+        #[serde(alias = "existing_data_files_count")]
         pub existing_files_count: i32,
         /// Number of entries in the manifest that have status DELETED (2), when null this is assumed to be non-zero
+        #[serde(alias = "deleted_data_files_count")]
         pub deleted_files_count: i32,
         /// Number of rows in all of files in the manifest that have status ADDED, when null this is assumed to be non-zero
         pub added_rows_count: i64,
@@ -200,10 +206,13 @@ mod _serde {
         /// ID of the snapshot where the manifest file was added
         pub added_snapshot_id: i64,
         /// Number of entries in the manifest that have status ADDED (1), when null this is assumed to be non-zero
+        #[serde(alias = "added_data_files_count")]
         pub added_files_count: Option<i32>,
         /// Number of entries in the manifest that have status EXISTING (0), when null this is assumed to be non-zero
+        #[serde(alias = "existing_data_files_count")]
         pub existing_files_count: Option<i32>,
         /// Number of entries in the manifest that have status DELETED (2), when null this is assumed to be non-zero
+        #[serde(alias = "deleted_data_files_count")]
         pub deleted_files_count: Option<i32>,
         /// Number of rows in all of files in the manifest that have status ADDED, when null this is assumed to be non-zero
         pub added_rows_count: Option<i64>,

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -17,11 +17,10 @@ use futures::{future::join_all, stream, TryFutureExt, TryStreamExt};
 use iceberg_rust_spec::{
     manifest::{partition_value_schema, DataFile, ManifestEntry, Status},
     manifest_list::{
-        avro_value_to_manifest_list_entry, manifest_list_schema_v1, manifest_list_schema_v2,
-        manifest_list_schema_v3, Content, ManifestListEntry,
+        avro_value_to_manifest_list_entry, Content, ManifestListEntry,
     },
     snapshot::Snapshot,
-    table_metadata::{FormatVersion, TableMetadata},
+    table_metadata::TableMetadata,
     util::strip_prefix,
 };
 use object_store::{ObjectStore, ObjectStoreExt};
@@ -96,13 +95,19 @@ impl<'metadata, R: Read> ManifestListReader<'_, 'metadata, R> {
     /// * The Avro reader cannot be created with the schema
     /// * The manifest list format is invalid
     pub(crate) fn new(reader: R, table_metadata: &'metadata TableMetadata) -> Result<Self, Error> {
-        let schema: &AvroSchema = match table_metadata.format_version {
-            FormatVersion::V1 => manifest_list_schema_v1(),
-            FormatVersion::V2 => manifest_list_schema_v2(),
-            FormatVersion::V3 => manifest_list_schema_v3(),
-        };
+        // We intentionally read without a reader schema so that the embedded writer schema is used.
+        // Some query engines (e.g. AWS Athena) write legacy field names such as
+        // `added_data_files_count` instead of the spec-correct `added_files_count` (see
+        // https://github.com/apache/iceberg/issues/8684). Supplying a reader schema causes
+        // apache_avro to perform Avro-level field resolution by name, which fails for those
+        // files because avro-rs has no alias support.  Without a reader schema the raw field
+        // names from the file reach the serde layer, where `#[serde(alias)]` can map both the
+        // legacy and the canonical names.
+        //
+        // TODO: switch back to `AvroReader::with_schema` once all major query engines write
+        // the spec-correct field names.
         Ok(Self {
-            reader: AvroReader::with_schema(schema, reader)?
+            reader: AvroReader::new(reader)?
                 .zip(repeat(table_metadata))
                 .map(|(avro_value_res, meta)| {
                     avro_value_to_manifest_list_entry(avro_value_res, meta).map_err(Error::from)

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -16,9 +16,7 @@ use apache_avro::{
 use futures::{future::join_all, stream, TryFutureExt, TryStreamExt};
 use iceberg_rust_spec::{
     manifest::{partition_value_schema, DataFile, ManifestEntry, Status},
-    manifest_list::{
-        avro_value_to_manifest_list_entry, Content, ManifestListEntry,
-    },
+    manifest_list::{avro_value_to_manifest_list_entry, Content, ManifestListEntry},
     snapshot::Snapshot,
     table_metadata::TableMetadata,
     util::strip_prefix,
@@ -107,11 +105,11 @@ impl<'metadata, R: Read> ManifestListReader<'_, 'metadata, R> {
         // TODO: switch back to `AvroReader::with_schema` once all major query engines write
         // the spec-correct field names.
         Ok(Self {
-            reader: AvroReader::new(reader)?
-                .zip(repeat(table_metadata))
-                .map(|(avro_value_res, meta)| {
+            reader: AvroReader::new(reader)?.zip(repeat(table_metadata)).map(
+                |(avro_value_res, meta)| {
                     avro_value_to_manifest_list_entry(avro_value_res, meta).map_err(Error::from)
-                }),
+                },
+            ),
         })
     }
 }


### PR DESCRIPTION
## Summary

- AWS Athena (and possibly other engines) writes `added_data_files_count`, `existing_data_files_count`, and `deleted_data_files_count` in manifest list files instead of the spec-correct names — a known early misalignment tracked in [apache/iceberg#8684](https://github.com/apache/iceberg/issues/8684)
- Reading such files failed with `Missing field in record: "added_files_count"` because `apache_avro` performs Avro-level field resolution by name when a reader schema is supplied, and `avro-rs` has no alias support
- Fix: read without a reader schema (using the embedded writer schema) so the raw field names reach the serde layer, then use `#[serde(alias)]` to accept both the legacy and spec-correct names on all three affected fields across V1/V2/V3 serde structs
- A `TODO` comment marks the reader-schema removal as temporary — to be reverted once all major query engines write the spec-correct names

Fixes #367

## Test plan

- [ ] Existing `test_manifest_list_v1/v2/v3` unit tests pass
- [ ] Manually verify reading a manifest list written by Athena resolves without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)