### PR TITLE
fix: expose concurency control for manifest read/write operations

### DIFF
--- a/datafusion_iceberg/src/table/mod.rs
+++ b/datafusion_iceberg/src/table/mod.rs
@@ -574,6 +574,7 @@ async fn table_scan(
                 .await
                 .map_err(DataFusionIcebergError::from)?
                 .try_collect()
+                .await
                 .map_err(DataFusionIcebergError::from)?
         } else {
             table
@@ -581,6 +582,7 @@ async fn table_scan(
                 .await
                 .map_err(DataFusionIcebergError::from)?
                 .try_collect()
+                .await
                 .map_err(DataFusionIcebergError::from)?
         };
 
@@ -617,6 +619,7 @@ async fn table_scan(
             .await
             .map_err(DataFusionIcebergError::from)?
             .try_collect()
+            .await
             .map_err(DataFusionIcebergError::from)?;
 
         let mut statistics = statistics_from_datafiles(&schema, &data_files);

--- a/iceberg-rust/src/config.rs
+++ b/iceberg-rust/src/config.rs
@@ -1,0 +1,24 @@
+//! Process-wide runtime configuration for the iceberg-rust crate.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Default number of concurrent manifest object-store operations (reads during scan planning,
+/// deletes during maintenance).
+pub const DEFAULT_CONCURRENT_MANIFEST_OPS: usize = 64;
+
+static CONCURRENT_MANIFEST_OPS: AtomicUsize = AtomicUsize::new(DEFAULT_CONCURRENT_MANIFEST_OPS);
+
+/// Set the maximum number of concurrent manifest object-store operations.
+///
+/// This bounds both in-flight object-store requests and peak manifest-decode memory. It applies
+/// to manifest reads during scan planning and to object-store fan-out in maintenance operations
+/// (e.g. dropping a table's files). The value is clamped to at least 1 and applies process-wide
+/// to all subsequent operations.
+pub fn set_concurrent_manifest_ops(limit: usize) {
+    CONCURRENT_MANIFEST_OPS.store(limit.max(1), Ordering::Relaxed);
+}
+
+/// Current maximum number of concurrent manifest object-store operations.
+pub fn concurrent_manifest_ops() -> usize {
+    CONCURRENT_MANIFEST_OPS.load(Ordering::Relaxed)
+}

--- a/iceberg-rust/src/lib.rs
+++ b/iceberg-rust/src/lib.rs
@@ -63,6 +63,7 @@
 
 pub mod arrow;
 pub mod catalog;
+pub mod config;
 pub mod error;
 pub mod file_format;
 pub mod materialized_view;

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -13,7 +13,7 @@ use std::{
 use apache_avro::{
     types::Value as AvroValue, Reader as AvroReader, Schema as AvroSchema, Writer as AvroWriter,
 };
-use futures::{future::join_all, stream, TryFutureExt, TryStreamExt};
+use futures::{future::join_all, TryFutureExt, TryStreamExt};
 use iceberg_rust_spec::{
     manifest::{partition_value_schema, DataFile, ManifestEntry, Status},
     manifest_list::{
@@ -256,7 +256,7 @@ pub async fn snapshot_column_bounds(
 
     let primitive_field_ids = schema.primitive_field_ids().collect::<Vec<_>>();
     let n = primitive_field_ids.len();
-    stream::iter(datafiles)
+    datafiles
         .try_fold(None::<Rectangle>, |acc, (_, manifest)| {
             let primitive_field_ids = &primitive_field_ids;
             async move {

--- a/iceberg-rust/src/table/mod.rs
+++ b/iceberg-rust/src/table/mod.rs
@@ -12,7 +12,6 @@
 
 use std::{io::Cursor, sync::Arc};
 
-use futures::future::try_join_all;
 use itertools::Itertools;
 use manifest::ManifestReader;
 use manifest_list::read_snapshot;
@@ -328,11 +327,12 @@ async fn datafiles(
     };
 
     let futures: Vec<_> = iter
-        .map(move |file| {
+        .map(|file| {
             let object_store = object_store.clone();
+            let manifest_path = file.manifest_path.clone();
+            let manifest_sequence_number = file.sequence_number;
             async move {
-                let manifest_path = &file.manifest_path;
-                let path: Path = util::strip_prefix(manifest_path).into();
+                let path: Path = util::strip_prefix(&manifest_path).into();
                 let bytes = Cursor::new(Vec::from(
                     object_store
                         .get(&path)
@@ -340,43 +340,38 @@ async fn datafiles(
                         .instrument(tracing::trace_span!("iceberg_rust::get_manifest"))
                         .await?,
                 ));
-                Ok::<_, Error>((bytes, manifest_path, file.sequence_number))
+
+                ManifestReader::new(bytes)?
+                    .filter_map_ok(|mut x| {
+                        let sequence_number = if let Some(sequence_number) = x.sequence_number() {
+                            *sequence_number
+                        } else {
+                            *x.sequence_number_mut() = Some(manifest_sequence_number);
+                            manifest_sequence_number
+                        };
+
+                        let keep = match sequence_number_range {
+                            (Some(start), Some(end)) => {
+                                start < sequence_number && sequence_number <= end
+                            }
+                            (Some(start), None) => start < sequence_number,
+                            (None, Some(end)) => sequence_number <= end,
+                            _ => true,
+                        };
+                        keep.then(|| (manifest_path.clone(), x))
+                    })
+                    .collect::<Result<Vec<_>, Error>>()
             }
         })
         .collect();
 
-    let results = try_join_all(futures).await?;
+    // Bounded concurrency caps in-flight object-store requests and peak decode memory.
+    let entries: Vec<(ManifestPath, ManifestEntry)> = stream::iter(futures)
+        .buffered(crate::config::concurrent_manifest_ops())
+        .try_concat()
+        .await?;
 
-    Ok(results.into_iter().flat_map(move |result| {
-        let (bytes, path, sequence_number) = result;
-
-        let reader = ManifestReader::new(bytes).unwrap();
-        reader.filter_map(move |x| {
-            let mut x = match x {
-                Ok(entry) => entry,
-                Err(err) => return Some(Err(err)),
-            };
-
-            let sequence_number = if let Some(sequence_number) = x.sequence_number() {
-                *sequence_number
-            } else {
-                *x.sequence_number_mut() = Some(sequence_number);
-                sequence_number
-            };
-
-            let filter = match sequence_number_range {
-                (Some(start), Some(end)) => start < sequence_number && sequence_number <= end,
-                (Some(start), None) => start < sequence_number,
-                (None, Some(end)) => sequence_number <= end,
-                _ => true,
-            };
-            if filter {
-                Some(Ok((path.to_owned(), x)))
-            } else {
-                None
-            }
-        })
-    }))
+    Ok(entries.into_iter().map(Ok))
 }
 
 /// delete all datafiles, manifests and metadata files, does not remove table from catalog
@@ -394,9 +389,10 @@ pub(crate) async fn delete_all_table_files(
     let datafiles = datafiles(object_store.clone(), &manifests, None, (None, None)).await?;
     let snapshots = &metadata.snapshots;
 
-    // stream::iter(datafiles.into_iter())
+    let concurrency = crate::config::concurrent_manifest_ops();
+
     stream::iter(datafiles)
-        .try_for_each_concurrent(None, |datafile| {
+        .try_for_each_concurrent(concurrency, |datafile| {
             let object_store = object_store.clone();
             async move {
                 object_store
@@ -409,7 +405,7 @@ pub(crate) async fn delete_all_table_files(
 
     stream::iter(manifests)
         .map(Ok::<_, Error>)
-        .try_for_each_concurrent(None, |manifest| {
+        .try_for_each_concurrent(concurrency, |manifest| {
             let object_store = object_store.clone();
             async move {
                 object_store.delete(&manifest.manifest_path.into()).await?;
@@ -420,7 +416,7 @@ pub(crate) async fn delete_all_table_files(
 
     stream::iter(snapshots.values())
         .map(Ok::<_, Error>)
-        .try_for_each_concurrent(None, |snapshot| {
+        .try_for_each_concurrent(concurrency, |snapshot| {
             let object_store = object_store.clone();
             async move {
                 object_store

--- a/iceberg-rust/src/table/mod.rs
+++ b/iceberg-rust/src/table/mod.rs
@@ -18,7 +18,7 @@ use manifest_list::read_snapshot;
 use object_store::ObjectStoreExt;
 use object_store::{path::Path, ObjectStore};
 
-use futures::{stream, StreamExt, TryFutureExt, TryStreamExt};
+use futures::{stream, Stream, StreamExt, TryFutureExt, TryStreamExt};
 use iceberg_rust_spec::util::{self};
 use iceberg_rust_spec::{
     spec::{
@@ -262,8 +262,7 @@ impl Table {
         manifests: &'a [ManifestListEntry],
         filter: Option<Vec<bool>>,
         sequence_number_range: (Option<i64>, Option<i64>),
-    ) -> Result<impl Iterator<Item = Result<(ManifestPath, ManifestEntry), Error>> + 'a, Error>
-    {
+    ) -> Result<impl Stream<Item = Result<(ManifestPath, ManifestEntry), Error>> + 'a, Error> {
         datafiles(
             self.object_store(),
             manifests,
@@ -280,7 +279,7 @@ impl Table {
     ) -> Result<bool, Error> {
         let manifests = self.manifests(start, end).await?;
         let datafiles = self.datafiles(&manifests, None, (None, None)).await?;
-        stream::iter(datafiles)
+        datafiles
             .try_any(|entry| async move { !matches!(entry.1.data_file().content(), Content::Data) })
             .await
     }
@@ -312,7 +311,7 @@ async fn datafiles(
     manifests: &'_ [ManifestListEntry],
     filter: Option<Vec<bool>>,
     sequence_number_range: (Option<i64>, Option<i64>),
-) -> Result<impl Iterator<Item = Result<(ManifestPath, ManifestEntry), Error>> + '_, Error> {
+) -> Result<impl Stream<Item = Result<(ManifestPath, ManifestEntry), Error>> + '_, Error> {
     // filter manifest files according to filter vector
     let iter: Box<dyn Iterator<Item = &ManifestListEntry> + Send + Sync> = match filter {
         Some(predicate) => {
@@ -365,13 +364,13 @@ async fn datafiles(
         })
         .collect();
 
-    // Bounded concurrency caps in-flight object-store requests and peak decode memory.
-    let entries: Vec<(ManifestPath, ManifestEntry)> = stream::iter(futures)
+    // `buffered` keeps at most `concurrent_manifest_ops` fetch+decode futures in flight, bounding
+    // request fan-out and the raw manifest bytes held at once (each future drops its bytes once
+    // decoded).
+    Ok(stream::iter(futures)
         .buffered(crate::config::concurrent_manifest_ops())
-        .try_concat()
-        .await?;
-
-    Ok(entries.into_iter().map(Ok))
+        .map_ok(|entries| stream::iter(entries.into_iter().map(Ok::<_, Error>)))
+        .try_flatten())
 }
 
 /// delete all datafiles, manifests and metadata files, does not remove table from catalog
@@ -391,7 +390,7 @@ pub(crate) async fn delete_all_table_files(
 
     let concurrency = crate::config::concurrent_manifest_ops();
 
-    stream::iter(datafiles)
+    datafiles
         .try_for_each_concurrent(concurrency, |datafile| {
             let object_store = object_store.clone();
             async move {

--- a/iceberg-rust/tests/overwrite_test.rs
+++ b/iceberg-rust/tests/overwrite_test.rs
@@ -188,12 +188,15 @@ async fn test_table_transaction_overwrite() {
 
     for manifest_entry in final_manifest_entries {
         let manifest_entries = vec![manifest_entry];
-        let mut data_files = table
+        let data_files = table
             .datafiles(&manifest_entries, None, (None, None))
             .await
-            .expect("Failed to read data files");
+            .expect("Failed to read data files")
+            .collect::<Vec<_>>()
+            .await;
 
         data_files
+            .into_iter()
             .try_for_each(|result| {
                 let (_, entry) = result?;
                 total_data_files += 1;
@@ -241,12 +244,15 @@ async fn test_table_transaction_overwrite() {
     let mut all_manifest_entries = Vec::new();
     for manifest_entry in final_manifest_entries_for_read {
         let manifest_entries = vec![manifest_entry];
-        let mut data_files = table
+        let data_files = table
             .datafiles(&manifest_entries, None, (None, None))
             .await
-            .expect("Failed to read data files for verification");
+            .expect("Failed to read data files for verification")
+            .collect::<Vec<_>>()
+            .await;
 
         data_files
+            .into_iter()
             .try_for_each(|result| {
                 all_manifest_entries.push(result?.1);
                 Ok::<_, Error>(())
@@ -430,14 +436,16 @@ async fn create_files_to_overwrite_for_partition(
 
         // Read the data files from this manifest
         let manifest_entries = vec![manifest_entry];
-        let mut data_files = table
+        let data_files = table
             .datafiles(&manifest_entries, None, (None, None))
-            .await?;
+            .await?
+            .collect::<Vec<_>>()
+            .await;
 
         let mut files_to_overwrite_in_manifest = Vec::new();
 
         // Find files that match the target partition
-        data_files.try_for_each(|result| {
+        data_files.into_iter().try_for_each(|result| {
             let (_, manifest_entry) = result?;
             // Check if this file belongs to the target partition
             let should_overwrite = manifest_entry


### PR DESCRIPTION
Previously for queries involving many tables/manifests the `datafiles` call would fan out too aggressively, potentially leading to CP throttling etc.

With the new knob the users can control that now.