### PR TITLE
feat: introduce rest catalog cache primitives

### DIFF
--- a/catalogs/iceberg-rest-catalog/src/apis/catalog_api_api.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/catalog_api_api.rs
@@ -444,7 +444,7 @@ pub async fn commit_transaction(
     let uri_str = "transactions/commit".to_string();
     let method = reqwest::Method::POST;
 
-    fetch::fetch_empty(
+    fetch::fetch(
         configuration,
         method,
         prefix,
@@ -548,7 +548,7 @@ pub async fn drop_namespace(
 
     let method = reqwest::Method::DELETE;
 
-    fetch::fetch_empty(configuration, method, prefix, &uri_str, &(), None, None).await
+    fetch::fetch(configuration, method, prefix, &uri_str, &(), None, None).await
 }
 
 /// Remove a table from the catalog
@@ -571,7 +571,7 @@ pub async fn drop_table(
     );
     let method = reqwest::Method::DELETE;
 
-    fetch::fetch_empty(
+    fetch::fetch(
         configuration,
         method,
         prefix,
@@ -597,7 +597,7 @@ pub async fn drop_view(
     );
     let method = reqwest::Method::DELETE;
 
-    fetch::fetch_empty(configuration, method, prefix, &uri_str, &(), None, None).await
+    fetch::fetch(configuration, method, prefix, &uri_str, &(), None, None).await
 }
 
 /// List all namespaces at a certain level, optionally starting from a given parent namespace. If table accounting.tax.paid.info exists, using 'SELECT NAMESPACE IN accounting' would translate into `GET /namespaces?parent=accounting` and must return a namespace, [\"accounting\", \"tax\"] only. Using 'SELECT NAMESPACE IN accounting.tax' would translate into `GET /namespaces?parent=accounting%1Ftax` and must return a namespace, [\"accounting\", \"tax\", \"paid\"]. If `parent` is not provided, all top-level namespaces should be listed.
@@ -785,17 +785,14 @@ pub async fn load_namespace_metadata(
 ///
 /// The headers argument can control how the Iceberg catalog handles credentials (via
 /// `X-Iceberg-Access-Delegation`) and whether to use HTTP cache semantics (via `If-None-Match`).
-pub async fn load_table<T>(
+pub async fn load_table(
     configuration: &configuration::Configuration,
     prefix: Option<&str>,
     namespace: &str,
     table: &str,
     headers: HashMap<String, String>,
     snapshots: Option<&str>,
-) -> Result<T, Error<LoadTableError>>
-where
-    T: super::FromResponse<LoadTableError>,
-{
+) -> Result<super::Conditional<models::LoadTableResult>, Error<LoadTableError>> {
     let mut query_params = HashMap::new();
     if let Some(snapshots) = snapshots {
         query_params.insert("snapshots".to_owned(), snapshots.to_string());
@@ -807,7 +804,7 @@ where
         table = crate::apis::urlencode(table)
     );
 
-    fetch::fetch(
+    fetch::fetch_conditional(
         configuration,
         reqwest::Method::GET,
         prefix,
@@ -849,7 +846,7 @@ pub async fn namespace_exists(
 
     let method = reqwest::Method::HEAD;
 
-    fetch::fetch_empty(configuration, method, prefix, &uri_str, &(), None, None).await
+    fetch::fetch(configuration, method, prefix, &uri_str, &(), None, None).await
 }
 
 /// Register a table using given metadata file location.
@@ -887,7 +884,7 @@ pub async fn rename_table(
     let uri_str = "tables/rename".to_string();
     let method = reqwest::Method::POST;
 
-    fetch::fetch_empty(
+    fetch::fetch(
         configuration,
         method,
         prefix,
@@ -908,7 +905,7 @@ pub async fn rename_view(
     let uri_str = "views/rename".to_string();
     let method = reqwest::Method::POST;
 
-    fetch::fetch_empty(
+    fetch::fetch(
         configuration,
         method,
         prefix,
@@ -961,7 +958,7 @@ pub async fn report_metrics(
     );
     let method = reqwest::Method::POST;
 
-    fetch::fetch_empty(
+    fetch::fetch(
         configuration,
         method,
         prefix,
@@ -988,7 +985,7 @@ pub async fn table_exists(
 
     let method = reqwest::Method::HEAD;
 
-    fetch::fetch_empty(configuration, method, prefix, &uri_str, &(), None, None).await
+    fetch::fetch(configuration, method, prefix, &uri_str, &(), None, None).await
 }
 
 /// Set and/or remove properties on a namespace. The request body specifies a list of properties to remove and a map of key value pairs to update. Properties that are not in the request are not modified or removed by this call. Server implementations are not required to support namespace properties.
@@ -1058,5 +1055,5 @@ pub async fn view_exists(
 
     let method = reqwest::Method::HEAD;
 
-    fetch::fetch_empty(configuration, method, prefix, &uri_str, &(), None, None).await
+    fetch::fetch(configuration, method, prefix, &uri_str, &(), None, None).await
 }

--- a/catalogs/iceberg-rest-catalog/src/apis/catalog_api_api.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/catalog_api_api.rs
@@ -783,9 +783,44 @@ pub async fn load_namespace_metadata(
 /// Load a table from the catalog. The response contains the table's full metadata plus any extra
 /// configuration to apply to it, which may include credentials to use for subsequent requests.
 ///
-/// The headers argument can control how the Iceberg catalog handles credentials (via
-/// `X-Iceberg-Access-Delegation`) and whether to use HTTP cache semantics (via `If-None-Match`).
+/// The headers argument can control how the Iceberg catalog handles credentials via
+/// `X-Iceberg-Access-Delegation`. For HTTP cache semantics use [`load_table_conditional`].
 pub async fn load_table(
+    configuration: &configuration::Configuration,
+    prefix: Option<&str>,
+    namespace: &str,
+    table: &str,
+    headers: HashMap<String, String>,
+    snapshots: Option<&str>,
+) -> Result<models::LoadTableResult, Error<LoadTableError>> {
+    let mut query_params = HashMap::new();
+    if let Some(snapshots) = snapshots {
+        query_params.insert("snapshots".to_owned(), snapshots.to_string());
+    }
+
+    let uri_str = format!(
+        "namespaces/{namespace}/tables/{table}",
+        namespace = crate::apis::urlencode(namespace),
+        table = crate::apis::urlencode(table)
+    );
+
+    fetch::fetch(
+        configuration,
+        reqwest::Method::GET,
+        prefix,
+        &uri_str,
+        &(),
+        Some(headers),
+        Some(query_params),
+    )
+    .await
+}
+
+/// Load a table from the catalog with HTTP cache semantics. Pass an `If-None-Match` header with
+/// a previously received ETag to skip re-fetching unchanged metadata; the server returns
+/// `304 Not Modified` in that case and this function returns [`super::Conditional::NotModified`].
+/// Use [`load_table`] when caching is not needed.
+pub async fn load_table_conditional(
     configuration: &configuration::Configuration,
     prefix: Option<&str>,
     namespace: &str,

--- a/catalogs/iceberg-rest-catalog/src/apis/catalog_api_api.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/catalog_api_api.rs
@@ -780,22 +780,22 @@ pub async fn load_namespace_metadata(
     fetch::fetch(configuration, method, prefix, &uri_str, &(), None, None).await
 }
 
-/// Load a table from the catalog.  The response contains both configuration and table metadata. The configuration, if non-empty is used as additional configuration for the table that overrides catalog configuration. For example, this configuration may change the FileIO implementation to be used for the table.  The response also contains the table's full metadata, matching the table metadata JSON file.  The catalog configuration may contain credentials that should be used for subsequent requests for the table. The configuration key \"token\" is used to pass an access token to be used as a bearer token for table requests. Otherwise, a token may be passed using a RFC 8693 token type as a configuration key. For example, \"urn:ietf:params:oauth:token-type:jwt=<JWT-token>\".
-pub async fn load_table(
+/// Load a table from the catalog. The response contains the table's full metadata plus any extra
+/// configuration to apply to it, which may include credentials to use for subsequent requests.
+///
+/// The headers argument can control how the Iceberg catalog handles credentials (via
+/// `X-Iceberg-Access-Delegation`) and whether to use HTTP cache semantics (via `If-None-Match`).
+pub async fn load_table<T>(
     configuration: &configuration::Configuration,
     prefix: Option<&str>,
     namespace: &str,
     table: &str,
-    x_iceberg_access_delegation: Option<&str>,
+    headers: HashMap<String, String>,
     snapshots: Option<&str>,
-) -> Result<models::LoadTableResult, Error<LoadTableError>> {
-    let mut headers = HashMap::new();
-    if let Some(param_value) = x_iceberg_access_delegation {
-        headers.insert(
-            "X-Iceberg-Access-Delegation".to_owned(),
-            param_value.to_string(),
-        );
-    }
+) -> Result<T, Error<LoadTableError>>
+where
+    T: super::FromResponse<LoadTableError>,
+{
     let mut query_params = HashMap::new();
     if let Some(snapshots) = snapshots {
         query_params.insert("snapshots".to_owned(), snapshots.to_string());
@@ -806,11 +806,10 @@ pub async fn load_table(
         namespace = crate::apis::urlencode(namespace),
         table = crate::apis::urlencode(table)
     );
-    let method = reqwest::Method::GET;
 
     fetch::fetch(
         configuration,
-        method,
+        reqwest::Method::GET,
         prefix,
         &uri_str,
         &(),

--- a/catalogs/iceberg-rest-catalog/src/apis/fetch.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/fetch.rs
@@ -1,8 +1,75 @@
 use crate::apis::{configuration, ResponseContent};
 
-use super::Error;
+use super::{Conditional, Error};
 
+use async_trait::async_trait;
 use std::collections::HashMap;
+
+/// Turns a raw [`reqwest::Response`] into the caller's chosen output type. The output type
+/// selects how the response is interpreted, so a single [`fetch`] serves every case:
+/// - a `Deserialize` type parses the JSON body (an empty body is treated as `null`, so `()`
+///   works for endpoints with no content);
+/// - [`Conditional<T>`] additionally honours `304 Not Modified` and captures the response `ETag`.
+#[async_trait]
+pub trait FromResponse<E>: Sized {
+    async fn from_response(resp: reqwest::Response) -> Result<Self, Error<E>>;
+}
+
+#[async_trait]
+impl<T, E> FromResponse<E> for T
+where
+    T: serde::de::DeserializeOwned,
+    E: serde::de::DeserializeOwned,
+{
+    async fn from_response(resp: reqwest::Response) -> Result<Self, Error<E>> {
+        let status = resp.status();
+        let content = resp.text().await?;
+        if !status.is_client_error() && !status.is_server_error() {
+            let body = if content.is_empty() { "null" } else { &content };
+            serde_json::from_str(body).map_err(Error::from)
+        } else {
+            let entity: Option<E> = serde_json::from_str(&content).ok();
+            Err(Error::ResponseError(ResponseContent {
+                status,
+                content,
+                entity,
+            }))
+        }
+    }
+}
+
+#[async_trait]
+impl<T, E> FromResponse<E> for Conditional<T>
+where
+    T: serde::de::DeserializeOwned,
+    E: serde::de::DeserializeOwned,
+{
+    async fn from_response(resp: reqwest::Response) -> Result<Self, Error<E>> {
+        if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
+            return Ok(Conditional::NotModified);
+        }
+        // Capture the ETag before consuming the response body.
+        let etag = resp
+            .headers()
+            .get(reqwest::header::ETAG)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        let status = resp.status();
+        let content = resp.text().await?;
+        if !status.is_client_error() && !status.is_server_error() {
+            let body = if content.is_empty() { "null" } else { &content };
+            let value = serde_json::from_str(body).map_err(Error::from)?;
+            Ok(Conditional::Modified { value, etag })
+        } else {
+            let entity: Option<E> = serde_json::from_str(&content).ok();
+            Err(Error::ResponseError(ResponseContent {
+                status,
+                content,
+                entity,
+            }))
+        }
+    }
+}
 
 pub(crate) async fn fetch<R, T, E>(
     configuration: &configuration::Configuration,
@@ -15,8 +82,7 @@ pub(crate) async fn fetch<R, T, E>(
 ) -> Result<T, Error<E>>
 where
     R: serde::Serialize + ?Sized,
-    T: for<'a> serde::Deserialize<'a>,
-    E: for<'a> serde::Deserialize<'a>,
+    T: FromResponse<E>,
 {
     let uri_base = build_uri_base(configuration, prefix);
     let client = &configuration.client;
@@ -70,21 +136,7 @@ where
 
     let req = req_builder.build()?;
     let resp = client.execute(req).await?;
-
-    let status = resp.status();
-    let content = resp.text().await?;
-
-    if !status.is_client_error() && !status.is_server_error() {
-        serde_json::from_str(&content).map_err(Error::from)
-    } else {
-        let entity: Option<E> = serde_json::from_str(&content).ok();
-        let error = ResponseContent {
-            status,
-            content,
-            entity,
-        };
-        Err(Error::ResponseError(error))
-    }
+    T::from_response(resp).await
 }
 
 pub(crate) async fn fetch_empty<R, E>(
@@ -98,75 +150,18 @@ pub(crate) async fn fetch_empty<R, E>(
 ) -> Result<(), Error<E>>
 where
     R: serde::Serialize + ?Sized,
-    E: for<'a> serde::Deserialize<'a>,
+    E: serde::de::DeserializeOwned,
 {
-    let uri_base = build_uri_base(configuration, prefix);
-    let client = &configuration.client;
-
-    let uri = uri_base + uri_str;
-    let mut req_builder = client.request(method.clone(), &uri);
-
-    for (key, value) in query_params.unwrap_or_default() {
-        req_builder = req_builder.query(&[(key, value)]);
-    }
-
-    if let Some(ref aws_v4_key) = configuration.aws_v4_key {
-        let body_str = match serde_json::to_value(&request) {
-            Ok(serde_json::Value::Null) => "",
-            _ => &serde_json::to_string(&request).expect("param should serialize to string"),
-        };
-        let uri_for_signing = match req_builder.try_clone() {
-            Some(cloned_builder) => match cloned_builder.build() {
-                Ok(tmp_req) => tmp_req.url().as_str().to_string(),
-                Err(_) => uri.clone(),
-            },
-            None => uri.clone(),
-        };
-        let new_headers = match aws_v4_key.sign(&uri_for_signing, method.as_str(), body_str) {
-            Ok(new_headers) => new_headers,
-            Err(err) => return Err(Error::AWSV4SignatureError(err)),
-        };
-        for (name, value) in new_headers.iter() {
-            req_builder = req_builder.header(name.as_str(), value.as_str());
-        }
-    }
-    if let Some(ref user_agent) = configuration.user_agent {
-        req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
-    }
-    if let Some(token) = configuration
-        .resolve_oauth_token()
-        .await
-        .map_err(Error::OAuthToken)?
-    {
-        req_builder = req_builder.bearer_auth(token);
-    };
-    if let Some(ref token) = configuration.bearer_access_token {
-        req_builder = req_builder.bearer_auth(token.to_owned());
-    };
-    for (key, value) in headers.unwrap_or_default() {
-        req_builder = req_builder.header(key, value);
-    }
-    if let &reqwest::Method::POST | &reqwest::Method::PUT = &method {
-        req_builder = req_builder.json(request);
-    }
-
-    let req = req_builder.build()?;
-    let resp = client.execute(req).await?;
-
-    let status = resp.status();
-    let content = resp.text().await?;
-
-    if !status.is_client_error() && !status.is_server_error() {
-        Ok(())
-    } else {
-        let entity: Option<E> = serde_json::from_str(&content).ok();
-        let error = ResponseContent {
-            status,
-            content,
-            entity,
-        };
-        Err(Error::ResponseError(error))
-    }
+    fetch(
+        configuration,
+        method,
+        prefix,
+        uri_str,
+        request,
+        headers,
+        query_params,
+    )
+    .await
 }
 
 /// Build the base URI for REST API calls with proper prefix encoding

--- a/catalogs/iceberg-rest-catalog/src/apis/fetch.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/fetch.rs
@@ -2,76 +2,9 @@ use crate::apis::{configuration, ResponseContent};
 
 use super::{Conditional, Error};
 
-use async_trait::async_trait;
 use std::collections::HashMap;
 
-/// Turns a raw [`reqwest::Response`] into the caller's chosen output type. The output type
-/// selects how the response is interpreted, so a single [`fetch`] serves every case:
-/// - a `Deserialize` type parses the JSON body (an empty body is treated as `null`, so `()`
-///   works for endpoints with no content);
-/// - [`Conditional<T>`] additionally honours `304 Not Modified` and captures the response `ETag`.
-#[async_trait]
-pub trait FromResponse<E>: Sized {
-    async fn from_response(resp: reqwest::Response) -> Result<Self, Error<E>>;
-}
-
-#[async_trait]
-impl<T, E> FromResponse<E> for T
-where
-    T: serde::de::DeserializeOwned,
-    E: serde::de::DeserializeOwned,
-{
-    async fn from_response(resp: reqwest::Response) -> Result<Self, Error<E>> {
-        let status = resp.status();
-        let content = resp.text().await?;
-        if !status.is_client_error() && !status.is_server_error() {
-            let body = if content.is_empty() { "null" } else { &content };
-            serde_json::from_str(body).map_err(Error::from)
-        } else {
-            let entity: Option<E> = serde_json::from_str(&content).ok();
-            Err(Error::ResponseError(ResponseContent {
-                status,
-                content,
-                entity,
-            }))
-        }
-    }
-}
-
-#[async_trait]
-impl<T, E> FromResponse<E> for Conditional<T>
-where
-    T: serde::de::DeserializeOwned,
-    E: serde::de::DeserializeOwned,
-{
-    async fn from_response(resp: reqwest::Response) -> Result<Self, Error<E>> {
-        if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
-            return Ok(Conditional::NotModified);
-        }
-        // Capture the ETag before consuming the response body.
-        let etag = resp
-            .headers()
-            .get(reqwest::header::ETAG)
-            .and_then(|v| v.to_str().ok())
-            .map(str::to_owned);
-        let status = resp.status();
-        let content = resp.text().await?;
-        if !status.is_client_error() && !status.is_server_error() {
-            let body = if content.is_empty() { "null" } else { &content };
-            let value = serde_json::from_str(body).map_err(Error::from)?;
-            Ok(Conditional::Modified { value, etag })
-        } else {
-            let entity: Option<E> = serde_json::from_str(&content).ok();
-            Err(Error::ResponseError(ResponseContent {
-                status,
-                content,
-                entity,
-            }))
-        }
-    }
-}
-
-pub(crate) async fn fetch<R, T, E>(
+pub(crate) async fn fetch_inner<R, E>(
     configuration: &configuration::Configuration,
     method: reqwest::Method,
     prefix: Option<&str>,
@@ -79,10 +12,9 @@ pub(crate) async fn fetch<R, T, E>(
     request: &R,
     headers: Option<HashMap<String, String>>,
     query_params: Option<HashMap<String, String>>,
-) -> Result<T, Error<E>>
+) -> Result<reqwest::Response, Error<E>>
 where
     R: serde::Serialize + ?Sized,
-    T: FromResponse<E>,
 {
     let uri_base = build_uri_base(configuration, prefix);
     let client = &configuration.client;
@@ -135,11 +67,10 @@ where
     }
 
     let req = req_builder.build()?;
-    let resp = client.execute(req).await?;
-    T::from_response(resp).await
+    client.execute(req).await.map_err(Error::from)
 }
 
-pub(crate) async fn fetch_empty<R, E>(
+pub(crate) async fn fetch<R, T, E>(
     configuration: &configuration::Configuration,
     method: reqwest::Method,
     prefix: Option<&str>,
@@ -147,21 +78,64 @@ pub(crate) async fn fetch_empty<R, E>(
     request: &R,
     headers: Option<HashMap<String, String>>,
     query_params: Option<HashMap<String, String>>,
-) -> Result<(), Error<E>>
+) -> Result<T, Error<E>>
 where
     R: serde::Serialize + ?Sized,
+    T: serde::de::DeserializeOwned,
     E: serde::de::DeserializeOwned,
 {
-    fetch(
-        configuration,
-        method,
-        prefix,
-        uri_str,
-        request,
-        headers,
-        query_params,
-    )
-    .await
+    let resp = fetch_inner(configuration, method, prefix, uri_str, request, headers, query_params).await?;
+    let status = resp.status();
+    let content = resp.text().await?;
+    if !status.is_client_error() && !status.is_server_error() {
+        let body = if content.is_empty() { "null" } else { &content };
+        serde_json::from_str(body).map_err(Error::from)
+    } else {
+        let entity: Option<E> = serde_json::from_str(&content).ok();
+        Err(Error::ResponseError(ResponseContent {
+            status,
+            content,
+            entity,
+        }))
+    }
+}
+
+pub(crate) async fn fetch_conditional<R, T, E>(
+    configuration: &configuration::Configuration,
+    method: reqwest::Method,
+    prefix: Option<&str>,
+    uri_str: &str,
+    request: &R,
+    headers: Option<HashMap<String, String>>,
+    query_params: Option<HashMap<String, String>>,
+) -> Result<Conditional<T>, Error<E>>
+where
+    R: serde::Serialize + ?Sized,
+    T: serde::de::DeserializeOwned,
+    E: serde::de::DeserializeOwned,
+{
+    let resp = fetch_inner(configuration, method, prefix, uri_str, request, headers, query_params).await?;
+    if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
+        return Ok(Conditional::NotModified);
+    }
+    let resp_headers = resp.headers().clone();
+    let status = resp.status();
+    let content = resp.text().await?;
+    if !status.is_client_error() && !status.is_server_error() {
+        let body = if content.is_empty() { "null" } else { &content };
+        let value = serde_json::from_str(body).map_err(Error::from)?;
+        Ok(Conditional::Modified {
+            value,
+            headers: resp_headers,
+        })
+    } else {
+        let entity: Option<E> = serde_json::from_str(&content).ok();
+        Err(Error::ResponseError(ResponseContent {
+            status,
+            content,
+            entity,
+        }))
+    }
 }
 
 /// Build the base URI for REST API calls with proper prefix encoding

--- a/catalogs/iceberg-rest-catalog/src/apis/fetch.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/fetch.rs
@@ -84,7 +84,16 @@ where
     T: serde::de::DeserializeOwned,
     E: serde::de::DeserializeOwned,
 {
-    let resp = fetch_inner(configuration, method, prefix, uri_str, request, headers, query_params).await?;
+    let resp = fetch_inner(
+        configuration,
+        method,
+        prefix,
+        uri_str,
+        request,
+        headers,
+        query_params,
+    )
+    .await?;
     let status = resp.status();
     let content = resp.text().await?;
     if !status.is_client_error() && !status.is_server_error() {
@@ -114,7 +123,16 @@ where
     T: serde::de::DeserializeOwned,
     E: serde::de::DeserializeOwned,
 {
-    let resp = fetch_inner(configuration, method, prefix, uri_str, request, headers, query_params).await?;
+    let resp = fetch_inner(
+        configuration,
+        method,
+        prefix,
+        uri_str,
+        request,
+        headers,
+        query_params,
+    )
+    .await?;
     if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
         return Ok(Conditional::NotModified);
     }

--- a/catalogs/iceberg-rest-catalog/src/apis/mod.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/mod.rs
@@ -10,6 +10,15 @@ pub struct ResponseContent<T> {
     pub entity: Option<T>,
 }
 
+/// Outcome of a conditional (ETag-validated) request.
+#[derive(Debug)]
+pub enum Conditional<T> {
+    /// Server returned `304 Not Modified`; the caller's cached value is still current.
+    NotModified,
+    /// Server returned a fresh body, along with its `ETag` if one was present.
+    Modified { value: T, etag: Option<String> },
+}
+
 #[derive(Debug)]
 pub enum Error<T> {
     Reqwest(reqwest::Error),
@@ -104,5 +113,7 @@ pub mod catalog_api_api;
 pub mod configuration_api_api;
 pub(crate) mod fetch;
 pub mod o_auth2_api_api;
+
+pub use fetch::FromResponse;
 
 pub mod configuration;

--- a/catalogs/iceberg-rest-catalog/src/apis/mod.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/mod.rs
@@ -15,8 +15,11 @@ pub struct ResponseContent<T> {
 pub enum Conditional<T> {
     /// Server returned `304 Not Modified`; the caller's cached value is still current.
     NotModified,
-    /// Server returned a fresh body, along with its `ETag` if one was present.
-    Modified { value: T, etag: Option<String> },
+    /// Server returned a fresh body along with all HTTP response headers.
+    Modified {
+        value: T,
+        headers: reqwest::header::HeaderMap,
+    },
 }
 
 #[derive(Debug)]
@@ -114,6 +117,5 @@ pub mod configuration_api_api;
 pub(crate) mod fetch;
 pub mod o_auth2_api_api;
 
-pub use fetch::FromResponse;
 
 pub mod configuration;

--- a/catalogs/iceberg-rest-catalog/src/apis/mod.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/mod.rs
@@ -117,5 +117,4 @@ pub mod configuration_api_api;
 pub(crate) mod fetch;
 pub mod o_auth2_api_api;
 
-
 pub mod configuration;

--- a/catalogs/iceberg-rest-catalog/src/catalog.rs
+++ b/catalogs/iceberg-rest-catalog/src/catalog.rs
@@ -343,12 +343,17 @@ impl Catalog for RestCatalog {
             )),
             Err(apis::Error::ResponseError(content)) => {
                 if content.status == 404 {
+                    let headers = HashMap::from([(
+                        "X-Iceberg-Access-Delegation".to_owned(),
+                        "vended-credentials".to_owned(),
+                    )]);
+
                     let response = catalog_api_api::load_table(
                         &configuration,
                         self.name.as_deref(),
                         &identifier.namespace().to_string(),
                         identifier.name(),
-                        Some("vended-credentials"),
+                        headers,
                         None,
                     )
                     .await

--- a/catalogs/iceberg-rest-catalog/src/catalog.rs
+++ b/catalogs/iceberg-rest-catalog/src/catalog.rs
@@ -359,10 +359,6 @@ impl Catalog for RestCatalog {
                     .await
                     .map_err(|_| Error::CatalogNotFound)?;
 
-                    let apis::Conditional::Modified { value: response, .. } = response else {
-                        return Err(Error::CatalogNotFound);
-                    };
-
                     let object_store = self.get_object_store(&response)?;
 
                     self.cache

--- a/catalogs/iceberg-rest-catalog/src/catalog.rs
+++ b/catalogs/iceberg-rest-catalog/src/catalog.rs
@@ -359,6 +359,10 @@ impl Catalog for RestCatalog {
                     .await
                     .map_err(|_| Error::CatalogNotFound)?;
 
+                    let apis::Conditional::Modified { value: response, .. } = response else {
+                        return Err(Error::CatalogNotFound);
+                    };
+
                     let object_store = self.get_object_store(&response)?;
 
                     self.cache


### PR DESCRIPTION
Progresses #268.

This PR adds new primitives for handling the HTTP cache semantics when loading a table:
- new `Conditional` enum in the rest crate
- generalizing fetch, so that it can accommodate both `LoadTableResult` and `Conditional<LoadTableResult>` via 
- a new `FromResponse` trait
- (drive-by) `fetch` and `fetch_empty` are consolidated to remove code duplication.

Finally, this is also exposed at the `catalog_api_api::load_table` level, which now accepts headers, and can return `Conditional::NotModified` when a `If-None-Match` headers is passed, end the ETag is still matching.