### PR TITLE
fix: resolve current_schema via current_schema_id, not the snapshot pin

### DIFF
--- a/catalogs/iceberg-glue-catalog/src/lib.rs
+++ b/catalogs/iceberg-glue-catalog/src/lib.rs
@@ -313,7 +313,7 @@ impl Catalog for GlueCatalog {
 
         object_store.put_version_hint(&metadata_location).await.ok();
 
-        let schema = metadata.current_schema(None)?;
+        let schema = metadata.current_schema()?;
 
         self.client
             .create_table()
@@ -470,7 +470,7 @@ impl Catalog for GlueCatalog {
 
         let schema = metadata.current_schema(None)?;
 
-        let table_schema = table_metadata.current_schema(None)?;
+        let table_schema = table_metadata.current_schema()?;
 
         // Create view
         self.client
@@ -580,7 +580,7 @@ impl Catalog for GlueCatalog {
 
         object_store.put_version_hint(&metadata_location).await.ok();
 
-        let schema = metadata.current_schema(None)?;
+        let schema = metadata.current_schema()?;
 
         self.client
             .update_table()
@@ -891,7 +891,7 @@ impl Catalog for GlueCatalog {
                 .await?,
         )?;
 
-        let schema = metadata.current_schema(None)?;
+        let schema = metadata.current_schema()?;
 
         self.client
             .create_table()

--- a/datafusion-iceberg-sql/src/lib.rs
+++ b/datafusion-iceberg-sql/src/lib.rs
@@ -25,10 +25,7 @@ impl TableSource for IcebergTableSource {
     fn schema(&self) -> SchemaRef {
         match &self.tabular {
             Tabular::Table(table) => {
-                let schema = table
-                    .current_schema(self.branch.as_deref())
-                    .or(table.current_schema(None))
-                    .unwrap();
+                let schema = table.current_schema().unwrap();
                 Arc::new((schema.fields()).try_into().unwrap())
             }
             Tabular::View(view) => {

--- a/datafusion_iceberg/src/materialized_view/mod.rs
+++ b/datafusion_iceberg/src/materialized_view/mod.rs
@@ -179,7 +179,7 @@ pub async fn refresh_materialized_view(
                 .fields()
                 .iter()
                 .map(|x| {
-                    let schema = storage_table.current_schema(branch.as_deref())?;
+                    let schema = storage_table.current_schema()?;
                     Ok(schema
                         .get_name(x.name())
                         .ok_or(Error::Schema(x.name().to_string(), schema.to_string()))?

--- a/datafusion_iceberg/src/table/mod.rs
+++ b/datafusion_iceberg/src/table/mod.rs
@@ -207,7 +207,7 @@ impl DataFusionTable {
             Tabular::Table(table) => {
                 let schema = end
                     .and_then(|snapshot_id| table.metadata().schema(snapshot_id).ok().cloned())
-                    .unwrap_or_else(|| table.current_schema(None).unwrap().clone());
+                    .unwrap_or_else(|| table.current_schema().unwrap().clone());
                 let mut builder =
                     SchemaBuilder::from(TryInto::<ArrowSchema>::try_into(schema.fields()).unwrap());
                 if config
@@ -452,7 +452,7 @@ async fn table_scan(
     let schema = snapshot_range
         .1
         .and_then(|snapshot_id| table.metadata().schema(snapshot_id).ok().cloned())
-        .unwrap_or_else(|| table.current_schema(None).unwrap().clone());
+        .unwrap_or_else(|| table.current_schema().unwrap().clone());
 
     // Create a unique URI for this particular object store
     let object_store_url = fake_object_store_url(&table.metadata().location);
@@ -471,7 +471,7 @@ async fn table_scan(
     let partition_fields = &snapshot_range
         .1
         .and_then(|snapshot_id| table.metadata().partition_fields(snapshot_id).ok())
-        .unwrap_or_else(|| table.metadata().current_partition_fields(None).unwrap());
+        .unwrap_or_else(|| table.metadata().current_partition_fields().unwrap());
 
     let sequence_number_range = [snapshot_range.0, snapshot_range.1]
         .iter()
@@ -1237,14 +1237,14 @@ async fn write_parquet_files(
 
     // Get table schema and metadata
     let schema = table
-        .current_schema(branch)
+        .current_schema()
         .map_err(DataFusionIcebergError::from)?;
     let arrow_schema = Arc::new(
         TryInto::<ArrowSchema>::try_into(schema.fields()).map_err(DataFusionIcebergError::from)?,
     );
 
     let partition_fields = metadata
-        .current_partition_fields(branch)
+        .current_partition_fields()
         .map_err(DataFusionIcebergError::from)?;
 
     let bucket = Bucket::from_path(&metadata.location).map_err(DataFusionIcebergError::from)?;
@@ -1293,7 +1293,7 @@ async fn write_parquet_files(
 
     let sink = ParquetSink::new(config, table_parquet_options);
 
-    let (demux_task, file_receiver) = start_demuxer_task(metadata, batches, context, branch)?;
+    let (demux_task, file_receiver) = start_demuxer_task(metadata, batches, context)?;
 
     sink.spawn_writer_tasks_and_join(context, demux_task, file_receiver, object_store.clone())
         .await?;
@@ -1328,7 +1328,6 @@ pub(crate) fn start_demuxer_task(
     metadata: &TableMetadata,
     data: SendableRecordBatchStream,
     context: &Arc<TaskContext>,
-    branch: Option<&str>,
 ) -> Result<
     (
         SpawnedTask<Result<(), DataFusionError>>,
@@ -1353,7 +1352,7 @@ pub(crate) fn start_demuxer_task(
         SpawnedTask::spawn({
             let partition_spec = partition_spec.clone();
             let schema = metadata
-                .current_schema(branch)
+                .current_schema()
                 .map_err(DataFusionIcebergError::from)?
                 .clone();
             let location = metadata.location.clone();

--- a/iceberg-rust-spec/src/spec/manifest.rs
+++ b/iceberg-rust-spec/src/spec/manifest.rs
@@ -1920,8 +1920,7 @@ mod tests {
         };
 
         let partition_schema =
-            partition_value_schema(&table_metadata.current_partition_fields(None).unwrap())
-                .unwrap();
+            partition_value_schema(&table_metadata.current_partition_fields().unwrap()).unwrap();
 
         let schema = ManifestEntry::schema(&partition_schema, &FormatVersion::V2).unwrap();
 
@@ -1977,7 +1976,7 @@ mod tests {
                 manifest_entry,
                 ManifestEntry::try_from_v2(
                     entry,
-                    table_metadata.current_schema(None).unwrap(),
+                    table_metadata.current_schema().unwrap(),
                     table_metadata.default_partition_spec().unwrap()
                 )
                 .unwrap()
@@ -2047,8 +2046,7 @@ mod tests {
         };
 
         let partition_schema =
-            partition_value_schema(&table_metadata.current_partition_fields(None).unwrap())
-                .unwrap();
+            partition_value_schema(&table_metadata.current_partition_fields().unwrap()).unwrap();
 
         let schema = ManifestEntry::schema(&partition_schema, &FormatVersion::V3).unwrap();
 
@@ -2102,7 +2100,7 @@ mod tests {
                 manifest_entry,
                 ManifestEntry::try_from_v3(
                     entry,
-                    table_metadata.current_schema(None).unwrap(),
+                    table_metadata.current_schema().unwrap(),
                     table_metadata.default_partition_spec().unwrap()
                 )
                 .unwrap()
@@ -2172,8 +2170,7 @@ mod tests {
         };
 
         let partition_schema =
-            partition_value_schema(&table_metadata.current_partition_fields(None).unwrap())
-                .unwrap();
+            partition_value_schema(&table_metadata.current_partition_fields().unwrap()).unwrap();
         let schema = ManifestEntry::schema(&partition_schema, &FormatVersion::V3).unwrap();
 
         let mut writer = apache_avro::Writer::new(&schema, vec![]);
@@ -2186,7 +2183,7 @@ mod tests {
             let entry = apache_avro::from_value::<ManifestEntryV3>(&value.unwrap()).unwrap();
             let parsed = ManifestEntry::try_from_v3(
                 entry,
-                table_metadata.current_schema(None).unwrap(),
+                table_metadata.current_schema().unwrap(),
                 table_metadata.default_partition_spec().unwrap(),
             )
             .unwrap();
@@ -2263,8 +2260,7 @@ mod tests {
         };
 
         let partition_schema =
-            partition_value_schema(&table_metadata.current_partition_fields(None).unwrap())
-                .unwrap();
+            partition_value_schema(&table_metadata.current_partition_fields().unwrap()).unwrap();
 
         let schema = ManifestEntry::schema(&partition_schema, &FormatVersion::V2).unwrap();
 
@@ -2320,7 +2316,7 @@ mod tests {
             manifest_entry,
             ManifestEntry::try_from_v2(
                 metadata_entry,
-                table_metadata.current_schema(None).unwrap(),
+                table_metadata.current_schema().unwrap(),
                 table_metadata.default_partition_spec().unwrap()
             )
             .unwrap()

--- a/iceberg-rust-spec/src/spec/manifest_list.rs
+++ b/iceberg-rust-spec/src/spec/manifest_list.rs
@@ -356,7 +356,7 @@ impl ManifestListEntry {
     ) -> Result<ManifestListEntry, Error> {
         let partition_types = table_metadata.default_partition_spec()?.data_types(
             table_metadata
-                .current_schema(None)
+                .current_schema()
                 .or(table_metadata
                     .refs
                     .values()
@@ -400,7 +400,7 @@ impl ManifestListEntry {
     ) -> Result<ManifestListEntry, Error> {
         let partition_types = table_metadata.default_partition_spec()?.data_types(
             table_metadata
-                .current_schema(None)
+                .current_schema()
                 .or(table_metadata
                     .refs
                     .values()
@@ -444,7 +444,7 @@ impl ManifestListEntry {
     ) -> Result<ManifestListEntry, Error> {
         let partition_types = table_metadata.default_partition_spec()?.data_types(
             table_metadata
-                .current_schema(None)
+                .current_schema()
                 .or(table_metadata
                     .refs
                     .values()

--- a/iceberg-rust-spec/src/spec/table_metadata.rs
+++ b/iceberg-rust-spec/src/spec/table_metadata.rs
@@ -162,14 +162,10 @@ impl TableMetadata {
     /// stamped its snapshot from this method, re-pinning the old schema
     /// forever.
     ///
-    /// # Arguments
-    /// * `_branch` - Retained for API compatibility; the current schema is a
-    ///   table-level property and does not vary by branch
-    ///
     /// # Returns
     /// * `Result<&Schema, Error>` - The current schema, or an error if the schema cannot be found
     #[inline]
-    pub fn current_schema(&self, _branch: Option<&str>) -> Result<&Schema, Error> {
+    pub fn current_schema(&self) -> Result<&Schema, Error> {
         self.schemas
             .get(&self.current_schema_id)
             .ok_or_else(|| Error::InvalidFormat("schema".to_string()))
@@ -205,19 +201,13 @@ impl TableMetadata {
             .ok_or_else(|| Error::InvalidFormat("partition spec".to_string()))
     }
 
-    /// Gets the current partition fields for a given branch, binding them to their source schema fields
-    ///
-    /// # Arguments
-    /// * `branch` - Optional branch name to get the partition fields for
+    /// Gets the current partition fields, binding them to their source schema fields
     ///
     /// # Returns
     /// * `Result<Vec<BoundPartitionField>, Error>` - Vector of partition fields bound to their source schema fields,
     ///   or an error if the schema or partition spec cannot be found
-    pub fn current_partition_fields(
-        &self,
-        branch: Option<&str>,
-    ) -> Result<Vec<BoundPartitionField<'_>>, Error> {
-        let schema = self.current_schema(branch)?;
+    pub fn current_partition_fields(&self) -> Result<Vec<BoundPartitionField<'_>>, Error> {
+        let schema = self.current_schema()?;
         let partition_spec = self.default_partition_spec()?;
         partition_fields(partition_spec, schema)
     }
@@ -2026,7 +2016,7 @@ mod tests {
         let metadata =
             serde_json::from_str::<TableMetadata>(data).expect("Failed to deserialize json");
 
-        let current = metadata.current_schema(None).expect("current schema");
+        let current = metadata.current_schema().expect("current schema");
         assert_eq!(*current.schema_id(), 1);
         assert!(current.fields().iter().any(|f| f.name == "label_env"));
 

--- a/iceberg-rust-spec/src/spec/table_metadata.rs
+++ b/iceberg-rust-spec/src/spec/table_metadata.rs
@@ -151,21 +151,27 @@ pub struct TableMetadata {
 }
 
 impl TableMetadata {
-    /// Gets the current schema for a given branch, or the table's current schema if no branch is specified.
+    /// Gets the table's current schema (`current-schema-id`).
+    ///
+    /// Per the Iceberg spec the table's authoritative schema is
+    /// `current-schema-id`; a snapshot's `schema-id` only records the schema
+    /// that was current when that snapshot was written (use
+    /// [`TableMetadata::schema`] for snapshot-scoped reads). Resolving via
+    /// the current snapshot here made `SetCurrentSchema` unreachable: the
+    /// old snapshot pinned the old schema id, and every new append/replace
+    /// stamped its snapshot from this method, re-pinning the old schema
+    /// forever.
     ///
     /// # Arguments
-    /// * `branch` - Optional branch name to get the schema for
+    /// * `_branch` - Retained for API compatibility; the current schema is a
+    ///   table-level property and does not vary by branch
     ///
     /// # Returns
     /// * `Result<&Schema, Error>` - The current schema, or an error if the schema cannot be found
     #[inline]
-    pub fn current_schema(&self, branch: Option<&str>) -> Result<&Schema, Error> {
-        let schema_id = self
-            .current_snapshot(branch)?
-            .and_then(|x| *x.schema_id())
-            .unwrap_or(self.current_schema_id);
+    pub fn current_schema(&self, _branch: Option<&str>) -> Result<&Schema, Error> {
         self.schemas
-            .get(&schema_id)
+            .get(&self.current_schema_id)
             .ok_or_else(|| Error::InvalidFormat("schema".to_string()))
     }
 
@@ -1959,6 +1965,78 @@ mod tests {
     // committed snapshots to the current schema id). Both scenarios live here
     // until that surface lands.
     // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_current_schema_resolves_via_current_schema_id_not_snapshot_pin() {
+        // A table whose only snapshot was written under schema 0, then evolved
+        // to schema 1 via AddSchema + SetCurrentSchema. current_schema() must
+        // return schema 1 (the table's authoritative schema); the snapshot's
+        // pinned schema stays reachable through schema(snapshot_id).
+        let data = r#"
+            {
+                "format-version": 2,
+                "table-uuid": "fb072c92-a02b-11e9-ae9c-1bb7bc9eca94",
+                "location": "s3://b/wh/data.db/table",
+                "last-sequence-number": 1,
+                "last-updated-ms": 1515100955770,
+                "last-column-id": 2,
+                "schemas": [
+                    {
+                        "schema-id": 0,
+                        "type": "struct",
+                        "fields": [
+                            {"id": 1, "name": "body", "required": false, "type": "string"}
+                        ]
+                    },
+                    {
+                        "schema-id": 1,
+                        "type": "struct",
+                        "fields": [
+                            {"id": 1, "name": "body", "required": false, "type": "string"},
+                            {"id": 2, "name": "label_env", "required": false, "type": "string"}
+                        ]
+                    }
+                ],
+                "current-schema-id": 1,
+                "partition-specs": [{"spec-id": 0, "fields": []}],
+                "default-spec-id": 0,
+                "last-partition-id": 0,
+                "properties": {},
+                "current-snapshot-id": 3051729675574597004,
+                "snapshots": [
+                    {
+                        "snapshot-id": 3051729675574597004,
+                        "timestamp-ms": 1515100955770,
+                        "sequence-number": 1,
+                        "schema-id": 0,
+                        "summary": {"operation": "append"},
+                        "manifest-list": "s3://a/b/1.avro"
+                    }
+                ],
+                "refs": {
+                    "main": {
+                        "snapshot-id": 3051729675574597004,
+                        "type": "branch"
+                    }
+                },
+                "sort-orders": [],
+                "default-sort-order-id": 0
+            }
+        "#;
+        let metadata =
+            serde_json::from_str::<TableMetadata>(data).expect("Failed to deserialize json");
+
+        let current = metadata.current_schema(None).expect("current schema");
+        assert_eq!(*current.schema_id(), 1);
+        assert!(current.fields().iter().any(|f| f.name == "label_env"));
+
+        // Snapshot-scoped reads still see the schema the snapshot was
+        // written under.
+        let pinned = metadata
+            .schema(3051729675574597004)
+            .expect("snapshot schema");
+        assert_eq!(*pinned.schema_id(), 0);
+    }
 
     #[test]
     #[ignore = "no append/delete builders; cannot drive multi-snapshot schema_id propagation"]

--- a/iceberg-rust-spec/src/spec/tabular.rs
+++ b/iceberg-rust-spec/src/spec/tabular.rs
@@ -147,14 +147,16 @@ impl TabularMetadataRef<'_> {
     /// Returns the current schema for the tabular object
     ///
     /// # Arguments
-    /// * `branch` - Optional branch name to get schema from
+    /// * `branch` - Optional branch name to get schema from (views and
+    ///   materialized views only; a table's current schema is a table-level
+    ///   property and does not vary by branch)
     ///
     /// # Returns
     /// * `Ok(&Schema)` - The current schema for this table, view, or materialized view
     /// * `Err(Error)` - If the schema cannot be retrieved
     pub fn current_schema(&self, branch: Option<&str>) -> Result<&Schema, Error> {
         match self {
-            TabularMetadataRef::Table(table) => table.current_schema(branch),
+            TabularMetadataRef::Table(table) => table.current_schema(),
             TabularMetadataRef::View(view) => view.current_schema(branch),
             TabularMetadataRef::MaterializedView(matview) => matview.current_schema(branch),
         }

--- a/iceberg-rust/src/arrow/write.rs
+++ b/iceberg-rust/src/arrow/write.rs
@@ -167,12 +167,7 @@ async fn store_parquet_partitioned(
 ) -> Result<Vec<DataFile>, ArrowError> {
     let metadata = table.metadata();
     let object_store = table.object_store();
-    let schema = Arc::new(
-        metadata
-            .current_schema(branch)
-            .map_err(Error::from)?
-            .clone(),
-    );
+    let schema = Arc::new(metadata.current_schema().map_err(Error::from)?.clone());
     // project the schema on to the equality_ids for equality deletes
     let schema = if let Some(equality_ids) = equality_ids {
         Arc::new(schema.project(equality_ids))
@@ -187,9 +182,7 @@ async fn store_parquet_partitioned(
             .clone(),
     );
 
-    let partition_fields = &metadata
-        .current_partition_fields(branch)
-        .map_err(Error::from)?;
+    let partition_fields = &metadata.current_partition_fields().map_err(Error::from)?;
 
     let data_location = &metadata
         .properties

--- a/iceberg-rust/src/table/manifest.rs
+++ b/iceberg-rust/src/table/manifest.rs
@@ -202,7 +202,6 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         schema: &'schema AvroSchema,
         table_metadata: &'metadata TableMetadata,
         content: manifest_list::Content,
-        branch: Option<&str>,
     ) -> Result<Self, Error> {
         let mut writer = AvroWriter::new(schema, Vec::new());
 
@@ -219,17 +218,17 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             "schema".to_string(),
             match table_metadata.format_version {
                 FormatVersion::V1 => serde_json::to_string(&Into::<SchemaV1>::into(
-                    table_metadata.current_schema(branch)?.clone(),
+                    table_metadata.current_schema()?.clone(),
                 ))?,
                 FormatVersion::V2 | FormatVersion::V3 => serde_json::to_string(
-                    &Into::<SchemaV2>::into(table_metadata.current_schema(branch)?.clone()),
+                    &Into::<SchemaV2>::into(table_metadata.current_schema()?.clone()),
                 )?,
             },
         )?;
 
         writer.add_user_metadata(
             "schema-id".to_string(),
-            serde_json::to_string(&table_metadata.current_schema(branch)?.schema_id())?,
+            serde_json::to_string(&table_metadata.current_schema()?.schema_id())?,
         )?;
 
         let spec_id = table_metadata.default_spec_id;
@@ -311,7 +310,6 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         mut manifest: ManifestListEntry,
         schema: &'schema AvroSchema,
         table_metadata: &'metadata TableMetadata,
-        branch: Option<&str>,
     ) -> Result<Self, Error> {
         let mut writer = AvroWriter::new(schema, Vec::new());
         writer.add_user_metadata(
@@ -327,17 +325,17 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             "schema".to_string(),
             match table_metadata.format_version {
                 FormatVersion::V1 => serde_json::to_string(&Into::<SchemaV1>::into(
-                    table_metadata.current_schema(branch)?.clone(),
+                    table_metadata.current_schema()?.clone(),
                 ))?,
                 FormatVersion::V2 | FormatVersion::V3 => serde_json::to_string(
-                    &Into::<SchemaV2>::into(table_metadata.current_schema(branch)?.clone()),
+                    &Into::<SchemaV2>::into(table_metadata.current_schema()?.clone()),
                 )?,
             },
         )?;
 
         writer.add_user_metadata(
             "schema-id".to_string(),
-            serde_json::to_string(&table_metadata.current_schema(branch)?.schema_id())?,
+            serde_json::to_string(&table_metadata.current_schema()?.schema_id())?,
         )?;
 
         let spec_id = table_metadata.default_spec_id;
@@ -446,7 +444,6 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
         filter: &HashSet<String>,
         schema: &'schema AvroSchema,
         table_metadata: &'metadata TableMetadata,
-        branch: Option<&str>,
     ) -> Result<(Self, FilteredManifestStats), Error> {
         let manifest_reader = ManifestReader::new(bytes)?;
 
@@ -466,17 +463,17 @@ impl<'schema, 'metadata> ManifestWriter<'schema, 'metadata> {
             "schema".to_string(),
             match table_metadata.format_version {
                 FormatVersion::V1 => serde_json::to_string(&Into::<SchemaV1>::into(
-                    table_metadata.current_schema(branch)?.clone(),
+                    table_metadata.current_schema()?.clone(),
                 ))?,
                 FormatVersion::V2 | FormatVersion::V3 => serde_json::to_string(
-                    &Into::<SchemaV2>::into(table_metadata.current_schema(branch)?.clone()),
+                    &Into::<SchemaV2>::into(table_metadata.current_schema()?.clone()),
                 )?,
             },
         )?;
 
         writer.add_user_metadata(
             "schema-id".to_string(),
-            serde_json::to_string(&table_metadata.current_schema(branch)?.schema_id())?,
+            serde_json::to_string(&table_metadata.current_schema()?.schema_id())?,
         )?;
 
         let spec_id = table_metadata.default_spec_id;

--- a/iceberg-rust/src/table/manifest_list.rs
+++ b/iceberg-rust/src/table/manifest_list.rs
@@ -251,7 +251,7 @@ pub async fn snapshot_column_bounds(
 ) -> Result<Option<Rectangle>, Error> {
     let schema = table_metadata
         .schema(*snapshot.snapshot_id())
-        .or(table_metadata.current_schema(None))?;
+        .or(table_metadata.current_schema())?;
     let manifests = read_snapshot(snapshot, table_metadata, object_store.clone())
         .await?
         .collect::<Result<Vec<_>, _>>()?;
@@ -322,7 +322,6 @@ pub async fn snapshot_column_bounds(
 /// * `selected_manifest` - Optional existing manifest that can be reused for appends
 /// * `bounding_partition_values` - Computed partition boundaries for the data files
 /// * `n_existing_files` - Count of existing files for split calculations
-/// * `branch` - Optional branch name for multi-branch table operations
 pub(crate) struct ManifestListWriter<'schema, 'metadata> {
     table_metadata: &'metadata TableMetadata,
     writer: AvroWriter<'schema, Vec<u8>>,
@@ -332,7 +331,6 @@ pub(crate) struct ManifestListWriter<'schema, 'metadata> {
     n_existing_files: usize,
     commit_uuid: String,
     manifest_count: usize,
-    branch: Option<String>,
 }
 
 impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
@@ -346,7 +344,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     /// * `data_files` - Iterator over data files to compute partition boundaries from
     /// * `schema` - The Avro schema to use for manifest list serialization
     /// * `table_metadata` - Reference to the table metadata for partition field information
-    /// * `branch` - Optional branch name for multi-branch table operations
     ///
     /// # Returns
     /// * `Result<Self, Error>` - A new ManifestListWriter instance or an error
@@ -363,16 +360,14 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     ///     data_files.iter(),
     ///     &manifest_list_schema,
     ///     &table_metadata,
-    ///     Some("main"),
     /// )?;
     /// ```
     pub(crate) fn new<'datafiles>(
         data_files: impl Iterator<Item = &'datafiles DataFile>,
         schema: &'schema AvroSchema,
         table_metadata: &'metadata TableMetadata,
-        branch: Option<&str>,
     ) -> Result<Self, Error> {
-        let partition_fields = table_metadata.current_partition_fields(branch)?;
+        let partition_fields = table_metadata.current_partition_fields()?;
 
         let partition_column_names = partition_fields
             .iter()
@@ -395,7 +390,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             n_existing_files: 0,
             commit_uuid,
             manifest_count: 0,
-            branch: branch.map(ToOwned::to_owned),
         })
     }
 
@@ -418,7 +412,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     /// * `data_files` - Iterator over new data files to be appended
     /// * `schema` - The Avro schema to use for manifest list serialization
     /// * `table_metadata` - Reference to the table metadata for partition field information
-    /// * `branch` - Optional branch name for multi-branch table operations
     ///
     /// # Returns
     /// * `Result<Self, Error>` - A new ManifestListWriter instance with selected manifest or an error
@@ -438,7 +431,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     ///     new_data_files.iter(),
     ///     &manifest_list_schema,
     ///     &table_metadata,
-    ///     Some("main"),
     /// )?;
     /// ```
     pub(crate) fn from_existing<'datafiles>(
@@ -446,9 +438,8 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         data_files: impl Iterator<Item = &'datafiles DataFile>,
         schema: &'schema AvroSchema,
         table_metadata: &'metadata TableMetadata,
-        branch: Option<&str>,
     ) -> Result<Self, Error> {
-        let partition_fields = table_metadata.current_partition_fields(branch)?;
+        let partition_fields = table_metadata.current_partition_fields()?;
 
         let partition_column_names = partition_fields
             .iter()
@@ -487,7 +478,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
             n_existing_files: file_count_all_entries,
             commit_uuid,
             manifest_count: 0,
-            branch: branch.map(ToOwned::to_owned),
         })
     }
 
@@ -511,7 +501,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     /// * `manifests_to_overwrite` - Set of manifest paths that should be excluded/overwritten
     /// * `schema` - The Avro schema to use for manifest list serialization
     /// * `table_metadata` - Reference to the table metadata for partition field information
-    /// * `branch` - Optional branch name for multi-branch table operations
     ///
     /// # Returns
     /// * `Result<(Self, Vec<ManifestListEntry>), Error>` - A tuple containing:
@@ -535,7 +524,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
     ///     &manifests_to_overwrite,
     ///     &manifest_list_schema,
     ///     &table_metadata,
-    ///     Some("main"),
     /// )?;
     /// ```
     pub(crate) fn from_existing_without_overwrites<'datafiles>(
@@ -544,9 +532,8 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         manifests_to_overwrite: &HashSet<String>,
         schema: &'schema AvroSchema,
         table_metadata: &'metadata TableMetadata,
-        branch: Option<&str>,
     ) -> Result<(Self, Vec<ManifestListEntry>), Error> {
-        let partition_fields = table_metadata.current_partition_fields(branch)?;
+        let partition_fields = table_metadata.current_partition_fields()?;
 
         let partition_column_names = partition_fields
             .iter()
@@ -591,7 +578,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                 n_existing_files: file_count_all_entries,
                 commit_uuid,
                 manifest_count: 0,
-                branch: branch.map(ToOwned::to_owned),
             },
             manifests,
         ))
@@ -815,9 +801,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         };
         let selected_manifest_bytes_opt = prefetch_manifest(&selected_manifest, &object_store);
 
-        let partition_fields = self
-            .table_metadata
-            .current_partition_fields(self.branch.as_deref())?;
+        let partition_fields = self.table_metadata.current_partition_fields()?;
 
         let manifest_schema = ManifestEntry::schema(
             &partition_value_schema(&partition_fields)?,
@@ -840,7 +824,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                             &filter,
                             &manifest_schema,
                             self.table_metadata,
-                            self.branch.as_deref(),
                         )?;
                     (manifest_writer, Some(filtered_stats))
                 } else {
@@ -850,7 +833,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                         manifest,
                         &manifest_schema,
                         self.table_metadata,
-                        self.branch.as_deref(),
                     )?;
                     (manifest_writer, None)
                 }
@@ -863,7 +845,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                     &manifest_schema,
                     self.table_metadata,
                     content,
-                    self.branch.as_deref(),
                 )?;
                 (manifest_writer, None)
             };
@@ -1056,9 +1037,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         } else {
             None
         };
-        let partition_fields = self
-            .table_metadata
-            .current_partition_fields(self.branch.as_deref())?;
+        let partition_fields = self.table_metadata.current_partition_fields()?;
 
         let partition_column_names = partition_fields
             .iter()
@@ -1145,7 +1124,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                     &manifest_schema,
                     self.table_metadata,
                     content,
-                    self.branch.as_deref(),
                 )?;
 
                 for manifest_entry in entries {
@@ -1264,9 +1242,7 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         data_files_to_filter: &HashMap<String, Vec<String>>,
         object_store: Arc<dyn ObjectStore>,
     ) -> Result<FilteredManifestStats, Error> {
-        let partition_fields = self
-            .table_metadata
-            .current_partition_fields(self.branch.as_deref())?;
+        let partition_fields = self.table_metadata.current_partition_fields()?;
 
         let manifest_schema = Arc::new(ManifestEntry::schema(
             &partition_value_schema(&partition_fields)?,
@@ -1276,7 +1252,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
         let futures = manifests_to_overwrite.into_iter().map(|mut manifest| {
             let object_store = object_store.clone();
             let manifest_schema = manifest_schema.clone();
-            let branch = self.branch.clone();
             let manifest_location = self.next_manifest_location();
             let table_metadata = self.table_metadata;
             async move {
@@ -1303,7 +1278,6 @@ impl<'schema, 'metadata> ManifestListWriter<'schema, 'metadata> {
                         &data_files_to_filter,
                         &manifest_schema,
                         table_metadata,
-                        branch.as_deref(),
                     )?;
 
                 // Apply filtered statistics

--- a/iceberg-rust/src/table/mod.rs
+++ b/iceberg-rust/src/table/mod.rs
@@ -146,18 +146,15 @@ impl Table {
         self.object_store.clone()
     }
     #[inline]
-    /// Returns the current schema for this table, optionally for a specific branch
-    ///
-    /// # Arguments
-    /// * `branch` - Optional branch name to get the schema for. If None, returns the main branch schema
+    /// Returns the current schema for this table (`current-schema-id`)
     ///
     /// # Returns
     /// * `Result<&Schema, Error>` - The current schema if found, or an error if the schema cannot be found
     ///
     /// # Errors
     /// Returns an error if the schema ID cannot be found in the table metadata
-    pub fn current_schema(&self, branch: Option<&str>) -> Result<&Schema, Error> {
-        self.metadata.current_schema(branch).map_err(Error::from)
+    pub fn current_schema(&self) -> Result<&Schema, Error> {
+        self.metadata.current_schema().map_err(Error::from)
     }
     #[inline]
     /// Returns a reference to this table's metadata

--- a/iceberg-rust/src/table/transaction/operation.rs
+++ b/iceberg-rust/src/table/transaction/operation.rs
@@ -163,15 +163,9 @@ impl Operation {
                         all_files.iter(),
                         manifest_list_schema,
                         table_metadata,
-                        branch.as_deref(),
                     )?
                 } else {
-                    ManifestListWriter::new(
-                        all_files.iter(),
-                        manifest_list_schema,
-                        table_metadata,
-                        branch.as_deref(),
-                    )?
+                    ManifestListWriter::new(all_files.iter(), manifest_list_schema, table_metadata)?
                 };
 
                 let snapshot_id = generate_snapshot_id();
@@ -262,11 +256,7 @@ impl Operation {
                         operation: snapshot_operation,
                         other: summary_fields,
                     })
-                    .with_schema_id(
-                        *table_metadata
-                            .current_schema(branch.as_deref())?
-                            .schema_id(),
-                    );
+                    .with_schema_id(*table_metadata.current_schema()?.schema_id());
                 if let Some(snapshot) = old_snapshot {
                     snapshot_builder.with_parent_snapshot_id(*snapshot.snapshot_id());
                 }
@@ -332,15 +322,9 @@ impl Operation {
                         data_files_iter,
                         manifest_list_schema,
                         table_metadata,
-                        branch.as_deref(),
                     )?
                 } else {
-                    ManifestListWriter::new(
-                        data_files_iter,
-                        manifest_list_schema,
-                        table_metadata,
-                        branch.as_deref(),
-                    )?
+                    ManifestListWriter::new(data_files_iter, manifest_list_schema, table_metadata)?
                 };
 
                 let new_datafile_iter = data_files.into_iter().map(|data_file| {
@@ -439,11 +423,7 @@ impl Operation {
                         operation: snapshot_operation,
                         other: summary_fields,
                     })
-                    .with_schema_id(
-                        *table_metadata
-                            .current_schema(branch.as_deref())?
-                            .schema_id(),
-                    );
+                    .with_schema_id(*table_metadata.current_schema()?.schema_id());
                 if let Some(snapshot) = old_snapshot {
                     snapshot_builder.with_parent_snapshot_id(*snapshot.snapshot_id());
                 }
@@ -477,10 +457,9 @@ impl Operation {
                     files.len(),
                     additional_summary
                 );
-                let partition_fields =
-                    table_metadata.current_partition_fields(branch.as_deref())?;
+                let partition_fields = table_metadata.current_partition_fields()?;
                 let old_snapshot = table_metadata.current_snapshot(branch.as_deref())?;
-                let schema = table_metadata.current_schema(branch.as_deref())?.clone();
+                let schema = table_metadata.current_schema()?.clone();
 
                 let partition_column_names = partition_fields
                     .iter()
@@ -538,7 +517,6 @@ impl Operation {
                         &manifest_schema,
                         table_metadata,
                         ManifestListContent::Data,
-                        branch.as_deref(),
                     )?;
 
                     for manifest_entry in new_datafile_iter {
@@ -570,7 +548,6 @@ impl Operation {
                             &manifest_schema,
                             table_metadata,
                             ManifestListContent::Data,
-                            branch.as_deref(),
                         )?;
 
                         for manifest_entry in entries {
@@ -708,7 +685,6 @@ impl Operation {
                         &manifests_to_overwrite,
                         manifest_list_schema,
                         table_metadata,
-                        branch.as_deref(),
                     )?;
 
                 let mut filtered_stats = manifest_list_writer
@@ -799,11 +775,7 @@ impl Operation {
                         operation: snapshot_operation,
                         other: summary_fields,
                     })
-                    .with_schema_id(
-                        *table_metadata
-                            .current_schema(branch.as_deref())?
-                            .schema_id(),
-                    );
+                    .with_schema_id(*table_metadata.current_schema()?.schema_id());
                 snapshot_builder.with_parent_snapshot_id(*old_snapshot.snapshot_id());
                 let snapshot = snapshot_builder.build()?;
 


### PR DESCRIPTION
Fixes #376.

`TableMetadata::current_schema` preferred the current snapshot's pinned `schema_id` over `current_schema_id`. That made `SetCurrentSchema` unreachable on any table that already has a snapshot: the old snapshot pins the old schema id, and the `Append`/`Replace` operations stamp their new snapshot's `schema_id` from `current_schema()`, re-pinning the old schema on every commit — so a schema evolution could never take effect and writers (which derive their Arrow schema from `current_schema`) kept producing the old shape.

Per the Iceberg spec, the table's authoritative schema is `current-schema-id`; a snapshot's `schema-id` records the schema that was current *when that snapshot was written*, and stays reachable via `TableMetadata::schema(snapshot_id)` for snapshot-scoped reads (time travel is unaffected).

With this change the four snapshot-stamping sites in `operation.rs` (which all call `current_schema()`) automatically stamp new snapshots with the current schema id, so the AddSchema → SetCurrentSchema → write sequence works end to end.

Includes a regression test: metadata with `schemas {0, 1}`, `current-schema-id: 1`, and a snapshot pinned to schema 0 — `current_schema(None)` must return schema 1 while `schema(snapshot_id)` still returns schema 0.

Context: SignalDB drives schema evolution from its compaction path (cedricziel/signaldb#734) and hit this as a hard blocker.