### PR TITLE
feat: enable WAL journaling and busy timeout for SQLite catalog connections

### DIFF
--- a/catalogs/iceberg-sql-catalog/src/lib.rs
+++ b/catalogs/iceberg-sql-catalog/src/lib.rs
@@ -62,8 +62,21 @@ impl SqlCatalog {
             pool_options = pool_options.max_connections(1);
         }
 
-        let pool = AnyPoolOptions::after_connect(pool_options, |connection, _| {
+        let is_sqlite = url.starts_with("sqlite");
+
+        let pool = AnyPoolOptions::after_connect(pool_options, move |connection, _| {
             Box::pin(async move {
+                if is_sqlite {
+                    // Enable write-ahead logging and a busy timeout on every SQLite
+                    // connection. WAL lets readers proceed during a write and makes
+                    // each write cheaper, so concurrent catalog commits don't
+                    // serialize behind an exclusive rollback-journal lock; the busy
+                    // timeout avoids immediate "database is locked" errors under
+                    // brief write contention. Both are no-ops on an in-memory
+                    // database.
+                    connection.execute("PRAGMA journal_mode=WAL;").await?;
+                    connection.execute("PRAGMA busy_timeout=30000;").await?;
+                }
                 connection
                     .execute(
                         "create table if not exists iceberg_tables (
@@ -770,12 +783,21 @@ impl SqlCatalogList {
 
         let mut pool_options = PoolOptions::new();
 
-        if url.starts_with("sqlite") {
+        let is_sqlite = url.starts_with("sqlite");
+
+        if is_sqlite {
             pool_options = pool_options.max_connections(1);
         }
 
-        let pool = AnyPoolOptions::after_connect(pool_options, |connection, _| {
+        let pool = AnyPoolOptions::after_connect(pool_options, move |connection, _| {
             Box::pin(async move {
+                if is_sqlite {
+                    // See SqlCatalog::new: WAL + a busy timeout keep concurrent
+                    // catalog commits from serializing behind an exclusive
+                    // rollback-journal lock. No-ops on an in-memory database.
+                    connection.execute("PRAGMA journal_mode=WAL;").await?;
+                    connection.execute("PRAGMA busy_timeout=30000;").await?;
+                }
                 connection
                     .execute(
                         "create table if not exists iceberg_tables (


### PR DESCRIPTION
## Problem

`SqlCatalog` / `SqlCatalogList` connect through sqlx's `Any` pool, which **does not set a journal mode by default** (an intentional sqlx choice, since switching modes needs an exclusive lock). So a file-backed SQLite catalog runs in the default **rollback journal**, where every write takes an exclusive lock that also blocks readers.

Under concurrent catalog-commit volume this serializes writers and can push a commit past its deadline. We hit this downstream in [SignalDB](https://github.com/cedricziel/signaldb): under steady trace/log ingestion, the *first-time* creation of a new table timed out on the `iceberg_tables` writes while other commits held the lock, so that signal never became queryable.

## Change

Set two pragmas in the existing `after_connect` hook, for SQLite URLs only, in both `SqlCatalog::new` and `SqlCatalogList::new`:

```rust
PRAGMA journal_mode=WAL;
PRAGMA busy_timeout=30000;
```

- **WAL** lets readers proceed during a write and makes each write cheaper, so concurrent commits don't serialize behind an exclusive rollback-journal lock. It's a persistent property of the database file.
- **busy_timeout** avoids immediate `SQLITE_BUSY` ("database is locked") errors under brief write contention.

Both pragmas are harmless no-ops on an in-memory database, and non-SQLite backends (Postgres/MySQL) are unaffected (`is_sqlite` guard). **No public API change** — this is a drop-in behavior improvement.

## Notes / open questions

- Downstreams currently work around this by opening a one-shot connection and running `PRAGMA journal_mode=WAL` before the pool starts (WAL persists on the file); this change makes that unnecessary.
- The `busy_timeout` value (30s) is hardcoded. Happy to make the pragmas configurable via a builder/`new_with_options` constructor instead if you'd prefer that shape.
- Happy to add a focused unit test (create a file-backed catalog, force the lazy pool to connect, assert `PRAGMA journal_mode` is `wal`) if you'd like one in this PR.