### PR TITLE
feat: honor the write.metadata.metrics.* table properties

### DIFF
--- a/iceberg-rust-spec/src/spec/table_metadata.rs
+++ b/iceberg-rust-spec/src/spec/table_metadata.rs
@@ -53,6 +53,16 @@ pub const WRITE_METADATA_METRICS_DISTINCT_COUNTS_ENABLED: &str =
 /// `write.parquet.bloom-filter-enabled.column.label_env = "true"`.
 pub const WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX: &str =
     "write.parquet.bloom-filter-enabled.column.";
+/// Default statistics mode for a table's columns: `none`, `counts`,
+/// `truncate(n)` or `full`. Defaults to `truncate(16)`.
+pub const WRITE_METADATA_METRICS_DEFAULT: &str = "write.metadata.metrics.default";
+/// Per-column statistics mode: append the column name, e.g.
+/// `write.metadata.metrics.column.body = "none"`. Overrides the default.
+pub const WRITE_METADATA_METRICS_COLUMN_PREFIX: &str = "write.metadata.metrics.column.";
+/// How many top-level columns the inferred default mode reaches. Columns past
+/// it are only measured when named explicitly. Defaults to 100.
+pub const WRITE_METADATA_METRICS_MAX_INFERRED_COLUMN_DEFAULTS: &str =
+    "write.metadata.metrics.max-inferred-column-defaults";
 
 pub use _serde::{TableMetadataV1, TableMetadataV2, TableMetadataV3};
 

--- a/iceberg-rust/src/file_format/metrics.rs
+++ b/iceberg-rust/src/file_format/metrics.rs
@@ -1,0 +1,448 @@
+/*!
+ * Metrics modes for data-file statistics.
+ *
+ * Iceberg lets a table decide how much per-column statistics a data file
+ * carries, through the `write.metadata.metrics.*` table properties. Statistics
+ * are stored inline in the manifest entry for every data file, so collecting
+ * full bounds for every column of a wide table — or for a column holding large
+ * strings, such as a JSON blob or a log body — makes manifests grow without
+ * making planning any better: bounds on such a column prune nothing, but they
+ * are carried on every entry forever.
+ *
+ * The supported modes, matching the spec:
+ *
+ * - `none` — no counts and no bounds
+ * - `counts` — value/null/NaN counts, no bounds
+ * - `truncate(n)` — counts plus bounds shortened to `n` units
+ * - `full` — counts plus untruncated bounds
+ *
+ * Resolution order for a column is `write.metadata.metrics.column.<name>`, then
+ * `write.metadata.metrics.default`, then `truncate(16)`. The inferred default
+ * only reaches the first `write.metadata.metrics.max-inferred-column-defaults`
+ * (100) top-level columns; past that a column must be named explicitly to be
+ * measured at all.
+ */
+
+use std::collections::HashMap;
+
+use iceberg_rust_spec::spec::values::Value;
+use iceberg_rust_spec::table_metadata::{
+    WRITE_METADATA_METRICS_COLUMN_PREFIX, WRITE_METADATA_METRICS_DEFAULT,
+    WRITE_METADATA_METRICS_MAX_INFERRED_COLUMN_DEFAULTS,
+};
+
+/// Bound length used when a table says nothing about metrics.
+pub const DEFAULT_TRUNCATE_LENGTH: usize = 16;
+
+/// Number of top-level columns the inferred default reaches.
+pub const DEFAULT_MAX_INFERRED_COLUMN_DEFAULTS: usize = 100;
+
+/// How much statistics to collect for one column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricsMode {
+    /// Collect nothing.
+    None,
+    /// Collect counts but no bounds.
+    Counts,
+    /// Collect counts and bounds shortened to the given number of units.
+    Truncate(usize),
+    /// Collect counts and untruncated bounds.
+    Full,
+}
+
+impl MetricsMode {
+    /// Parse a mode from a table-property value, case-insensitively.
+    ///
+    /// Returns `None` for anything unrecognized, so an unparsable property
+    /// falls back to the default rather than failing the write.
+    pub fn parse(value: &str) -> Option<MetricsMode> {
+        let value = value.trim().to_ascii_lowercase();
+        match value.as_str() {
+            "none" => Some(MetricsMode::None),
+            "counts" => Some(MetricsMode::Counts),
+            "full" => Some(MetricsMode::Full),
+            other => {
+                let length = other.strip_prefix("truncate(")?.strip_suffix(')')?;
+                let length: usize = length.trim().parse().ok()?;
+                // truncate(0) would leave a bound that carries no information.
+                (length > 0).then_some(MetricsMode::Truncate(length))
+            }
+        }
+    }
+
+    /// Whether value, null and NaN counts are collected under this mode.
+    pub fn records_counts(self) -> bool {
+        !matches!(self, MetricsMode::None)
+    }
+
+    /// Whether lower and upper bounds are collected under this mode.
+    pub fn records_bounds(self) -> bool {
+        matches!(self, MetricsMode::Truncate(_) | MetricsMode::Full)
+    }
+}
+
+/// The `write.metadata.metrics.*` configuration of a table.
+#[derive(Debug, Clone)]
+pub struct MetricsConfig {
+    default_mode: MetricsMode,
+    column_modes: HashMap<String, MetricsMode>,
+    max_inferred_column_defaults: usize,
+}
+
+impl Default for MetricsConfig {
+    fn default() -> Self {
+        MetricsConfig {
+            default_mode: MetricsMode::Truncate(DEFAULT_TRUNCATE_LENGTH),
+            column_modes: HashMap::new(),
+            max_inferred_column_defaults: DEFAULT_MAX_INFERRED_COLUMN_DEFAULTS,
+        }
+    }
+}
+
+impl MetricsConfig {
+    /// Read the configuration from a table's properties.
+    pub fn from_table_properties(properties: &HashMap<String, String>) -> Self {
+        let default_mode = properties
+            .get(WRITE_METADATA_METRICS_DEFAULT)
+            .and_then(|value| MetricsMode::parse(value))
+            .unwrap_or(MetricsMode::Truncate(DEFAULT_TRUNCATE_LENGTH));
+
+        let column_modes = properties
+            .iter()
+            .filter_map(|(key, value)| {
+                let column = key.strip_prefix(WRITE_METADATA_METRICS_COLUMN_PREFIX)?;
+                Some((column.to_owned(), MetricsMode::parse(value)?))
+            })
+            .collect();
+
+        let max_inferred_column_defaults = properties
+            .get(WRITE_METADATA_METRICS_MAX_INFERRED_COLUMN_DEFAULTS)
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_MAX_INFERRED_COLUMN_DEFAULTS);
+
+        MetricsConfig {
+            default_mode,
+            column_modes,
+            max_inferred_column_defaults,
+        }
+    }
+
+    /// The mode for a column, addressed by its full dotted name.
+    ///
+    /// `top_level_index` is the position of the column's root field in the
+    /// schema; a column past `max-inferred-column-defaults` only gets metrics
+    /// if it was named explicitly. Pass `None` when the position is unknown, in
+    /// which case the limit does not apply.
+    pub fn mode_for(&self, column_name: &str, top_level_index: Option<usize>) -> MetricsMode {
+        if let Some(mode) = self.column_modes.get(column_name) {
+            return *mode;
+        }
+        match top_level_index {
+            Some(index) if index >= self.max_inferred_column_defaults => MetricsMode::None,
+            _ => self.default_mode,
+        }
+    }
+}
+
+/// Shorten a lower bound to `length` units.
+///
+/// Truncating a lower bound can only make it smaller, so the result still
+/// bounds every value the original bounded. Types with no meaningful notion of
+/// truncation — numbers, fixed-width binary, UUIDs — pass through untouched.
+pub fn truncate_lower_bound(value: Value, length: usize) -> Value {
+    match value {
+        Value::String(string) => {
+            let truncated: String = string.chars().take(length).collect();
+            Value::String(truncated)
+        }
+        Value::Binary(bytes) => {
+            let mut truncated = bytes;
+            truncated.truncate(length);
+            Value::Binary(truncated)
+        }
+        other => other,
+    }
+}
+
+/// Shorten an upper bound to `length` units.
+///
+/// An upper bound must stay at or above every value it covers, so the truncated
+/// prefix is incremented. Returns `None` when the prefix cannot be incremented
+/// — every unit is already at its maximum — in which case the bound has to be
+/// dropped rather than understated.
+pub fn truncate_upper_bound(value: Value, length: usize) -> Option<Value> {
+    match value {
+        Value::String(string) => {
+            if string.chars().count() <= length {
+                return Some(Value::String(string));
+            }
+            let mut chars: Vec<char> = string.chars().take(length).collect();
+            while let Some(last) = chars.pop() {
+                if let Some(next) = next_char(last) {
+                    chars.push(next);
+                    return Some(Value::String(chars.into_iter().collect()));
+                }
+            }
+            None
+        }
+        Value::Binary(bytes) => {
+            if bytes.len() <= length {
+                return Some(Value::Binary(bytes));
+            }
+            let mut truncated = bytes;
+            truncated.truncate(length);
+            while let Some(last) = truncated.pop() {
+                if last != u8::MAX {
+                    truncated.push(last + 1);
+                    return Some(Value::Binary(truncated));
+                }
+            }
+            None
+        }
+        other => Some(other),
+    }
+}
+
+/// The next Unicode scalar value after `c`, skipping the surrogate range.
+fn next_char(c: char) -> Option<char> {
+    let mut code = c as u32 + 1;
+    // 0xD800..=0xDFFF are surrogates and never valid scalar values.
+    if (0xD800..=0xDFFF).contains(&code) {
+        code = 0xE000;
+    }
+    char::from_u32(code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_accepts_every_spec_mode_case_insensitively() {
+        assert_eq!(MetricsMode::parse("none"), Some(MetricsMode::None));
+        assert_eq!(MetricsMode::parse("NONE"), Some(MetricsMode::None));
+        assert_eq!(MetricsMode::parse("counts"), Some(MetricsMode::Counts));
+        assert_eq!(MetricsMode::parse("full"), Some(MetricsMode::Full));
+        assert_eq!(
+            MetricsMode::parse("truncate(24)"),
+            Some(MetricsMode::Truncate(24))
+        );
+        assert_eq!(
+            MetricsMode::parse(" Truncate( 8 ) "),
+            Some(MetricsMode::Truncate(8))
+        );
+    }
+
+    #[test]
+    fn parse_rejects_unusable_values() {
+        assert_eq!(MetricsMode::parse("truncate(0)"), None);
+        assert_eq!(MetricsMode::parse("truncate(-1)"), None);
+        assert_eq!(MetricsMode::parse("truncate()"), None);
+        assert_eq!(MetricsMode::parse("truncate"), None);
+        assert_eq!(MetricsMode::parse("everything"), None);
+        assert_eq!(MetricsMode::parse(""), None);
+    }
+
+    #[test]
+    fn modes_gate_counts_and_bounds() {
+        assert!(!MetricsMode::None.records_counts());
+        assert!(!MetricsMode::None.records_bounds());
+        assert!(MetricsMode::Counts.records_counts());
+        assert!(!MetricsMode::Counts.records_bounds());
+        assert!(MetricsMode::Truncate(4).records_counts());
+        assert!(MetricsMode::Truncate(4).records_bounds());
+        assert!(MetricsMode::Full.records_counts());
+        assert!(MetricsMode::Full.records_bounds());
+    }
+
+    #[test]
+    fn a_table_without_properties_truncates_to_sixteen() {
+        let config = MetricsConfig::from_table_properties(&HashMap::new());
+        assert_eq!(
+            config.mode_for("anything", Some(0)),
+            MetricsMode::Truncate(DEFAULT_TRUNCATE_LENGTH)
+        );
+    }
+
+    #[test]
+    fn a_per_column_mode_overrides_the_default() {
+        let properties = HashMap::from([
+            (
+                WRITE_METADATA_METRICS_DEFAULT.to_string(),
+                "counts".to_string(),
+            ),
+            (
+                format!("{WRITE_METADATA_METRICS_COLUMN_PREFIX}trace_id"),
+                "full".to_string(),
+            ),
+            (
+                format!("{WRITE_METADATA_METRICS_COLUMN_PREFIX}body"),
+                "none".to_string(),
+            ),
+        ]);
+        let config = MetricsConfig::from_table_properties(&properties);
+
+        assert_eq!(config.mode_for("trace_id", Some(0)), MetricsMode::Full);
+        assert_eq!(config.mode_for("body", Some(1)), MetricsMode::None);
+        assert_eq!(config.mode_for("other", Some(2)), MetricsMode::Counts);
+    }
+
+    #[test]
+    fn columns_past_the_inferred_limit_are_not_measured() {
+        let properties = HashMap::from([(
+            WRITE_METADATA_METRICS_MAX_INFERRED_COLUMN_DEFAULTS.to_string(),
+            "2".to_string(),
+        )]);
+        let config = MetricsConfig::from_table_properties(&properties);
+
+        assert!(config.mode_for("a", Some(0)).records_bounds());
+        assert!(config.mode_for("b", Some(1)).records_bounds());
+        assert_eq!(config.mode_for("c", Some(2)), MetricsMode::None);
+    }
+
+    #[test]
+    fn an_explicit_column_is_measured_past_the_inferred_limit() {
+        let properties = HashMap::from([
+            (
+                WRITE_METADATA_METRICS_MAX_INFERRED_COLUMN_DEFAULTS.to_string(),
+                "1".to_string(),
+            ),
+            (
+                format!("{WRITE_METADATA_METRICS_COLUMN_PREFIX}late"),
+                "full".to_string(),
+            ),
+        ]);
+        let config = MetricsConfig::from_table_properties(&properties);
+
+        assert_eq!(config.mode_for("late", Some(99)), MetricsMode::Full);
+        assert_eq!(config.mode_for("other", Some(99)), MetricsMode::None);
+    }
+
+    #[test]
+    fn an_unparsable_property_falls_back_instead_of_failing() {
+        let properties = HashMap::from([(
+            WRITE_METADATA_METRICS_DEFAULT.to_string(),
+            "sometimes".to_string(),
+        )]);
+        let config = MetricsConfig::from_table_properties(&properties);
+        assert_eq!(
+            config.mode_for("a", Some(0)),
+            MetricsMode::Truncate(DEFAULT_TRUNCATE_LENGTH)
+        );
+    }
+
+    #[test]
+    fn a_truncated_lower_bound_stays_below_the_original() {
+        let original = "abcdefghij".to_string();
+        let truncated = truncate_lower_bound(Value::String(original.clone()), 4);
+        let Value::String(truncated) = truncated else {
+            panic!("expected a string");
+        };
+        assert_eq!(truncated, "abcd");
+        assert!(truncated <= original);
+    }
+
+    #[test]
+    fn a_truncated_upper_bound_stays_above_the_original() {
+        let original = "abcdefghij".to_string();
+        let truncated = truncate_upper_bound(Value::String(original.clone()), 4).unwrap();
+        let Value::String(truncated) = truncated else {
+            panic!("expected a string");
+        };
+        assert_eq!(truncated, "abce");
+        assert!(truncated >= original);
+    }
+
+    #[test]
+    fn bounds_shorter_than_the_limit_are_left_alone() {
+        assert_eq!(
+            truncate_lower_bound(Value::String("ab".to_string()), 4),
+            Value::String("ab".to_string())
+        );
+        assert_eq!(
+            truncate_upper_bound(Value::String("ab".to_string()), 4),
+            Some(Value::String("ab".to_string()))
+        );
+    }
+
+    #[test]
+    fn truncation_counts_characters_not_bytes() {
+        // Four characters, ten bytes: truncating to 4 must keep all of them
+        // and must never split a character.
+        let original = "日本語だ".to_string();
+        assert_eq!(original.len(), 12);
+        let truncated = truncate_lower_bound(Value::String(original.clone()), 4);
+        assert_eq!(truncated, Value::String(original));
+
+        let Value::String(truncated) =
+            truncate_lower_bound(Value::String("日本語だより".to_string()), 3)
+        else {
+            panic!("expected a string");
+        };
+        assert_eq!(truncated, "日本語");
+    }
+
+    #[test]
+    fn an_upper_bound_carries_past_maximal_characters() {
+        // The last character cannot be incremented, so the carry moves left.
+        let original = format!("a{}{}z", char::MAX, char::MAX);
+        let Value::String(truncated) = truncate_upper_bound(Value::String(original.clone()), 3)
+            .expect("a bound is still representable")
+        else {
+            panic!("expected a string");
+        };
+        assert_eq!(truncated, "b");
+        assert!(truncated >= original);
+    }
+
+    #[test]
+    fn an_upper_bound_that_cannot_be_incremented_is_dropped() {
+        let original: String = std::iter::repeat_n(char::MAX, 4).collect();
+        assert_eq!(truncate_upper_bound(Value::String(original), 2), None);
+    }
+
+    #[test]
+    fn an_incremented_character_never_lands_on_a_surrogate() {
+        // U+D7FF is the last scalar before the surrogate range.
+        let original = format!("{}x", '\u{D7FF}');
+        let Value::String(truncated) =
+            truncate_upper_bound(Value::String(original.clone()), 1).unwrap()
+        else {
+            panic!("expected a string");
+        };
+        assert_eq!(truncated, "\u{E000}");
+        assert!(truncated >= original);
+    }
+
+    #[test]
+    fn binary_bounds_truncate_by_byte() {
+        assert_eq!(
+            truncate_lower_bound(Value::Binary(vec![1, 2, 3, 4]), 2),
+            Value::Binary(vec![1, 2])
+        );
+        assert_eq!(
+            truncate_upper_bound(Value::Binary(vec![1, 2, 3, 4]), 2),
+            Some(Value::Binary(vec![1, 3]))
+        );
+        assert_eq!(
+            truncate_upper_bound(Value::Binary(vec![1, 255, 255, 4]), 3),
+            Some(Value::Binary(vec![2]))
+        );
+        assert_eq!(
+            truncate_upper_bound(Value::Binary(vec![255, 255, 255]), 2),
+            None
+        );
+    }
+
+    #[test]
+    fn non_truncatable_types_pass_through() {
+        assert_eq!(
+            truncate_lower_bound(Value::LongInt(42), 2),
+            Value::LongInt(42)
+        );
+        assert_eq!(
+            truncate_upper_bound(Value::LongInt(42), 2),
+            Some(Value::LongInt(42))
+        );
+    }
+}

--- a/iceberg-rust/src/file_format/mod.rs
+++ b/iceberg-rust/src/file_format/mod.rs
@@ -2,4 +2,5 @@
  * Helper functions for different file formats.
 */
 
+pub mod metrics;
 pub mod parquet;

--- a/iceberg-rust/src/file_format/parquet.rs
+++ b/iceberg-rust/src/file_format/parquet.rs
@@ -23,6 +23,9 @@ use thrift::protocol::{TCompactOutputProtocol, TSerializable};
 use tracing::instrument;
 
 use crate::error::Error;
+use crate::file_format::metrics::{
+    truncate_lower_bound, truncate_upper_bound, MetricsConfig, MetricsMode,
+};
 
 /// Parquet file-level KV metadata key that opts in to HLL-based `distinct_count`
 /// estimation for `Int64` columns. A patched arrow-rs writer reads this entry
@@ -67,31 +70,59 @@ pub fn parquet_to_datafile(
         .collect::<Result<HashMap<String, PartitionField>, Error>>()?;
     let _parquet_schema = file_metadata.file_metadata().schema_descr_ptr();
 
+    let metrics_config = MetricsConfig::from_table_properties(table_properties);
+    // `max-inferred-column-defaults` counts top-level columns, so a nested
+    // column inherits the position of the field it hangs off.
+    let top_level_indices: HashMap<&str, usize> = schema
+        .iter()
+        .enumerate()
+        .map(|(index, field)| (field.name.as_str(), index))
+        .collect();
+
     let mut column_sizes = AvroMap(HashMap::new());
     let mut value_counts = AvroMap(HashMap::new());
     let mut null_value_counts = AvroMap(HashMap::new());
     let mut distinct_counts = write_distinct_counts.then(|| AvroMap(HashMap::new()));
     let mut lower_bounds: HashMap<i32, Value> = HashMap::new();
     let mut upper_bounds: HashMap<i32, Value> = HashMap::new();
+    // Which mode produced each column's bounds, so truncation can be applied
+    // once at the end rather than per row group.
+    let mut column_metrics_modes: HashMap<i32, MetricsMode> = HashMap::new();
 
     for row_group in file_metadata.row_groups() {
         for column in row_group.columns() {
             let column_name = column.column_descr().name();
+            let column_path = column.column_path().parts().join(".");
             let id = schema
-                .get_name(&column.column_path().parts().join("."))
+                .get_name(&column_path)
                 .ok_or_else(|| Error::Schema(column_name.to_string(), "".to_string()))?
                 .id;
+
+            let top_level_index = column_path
+                .split('.')
+                .next()
+                .and_then(|root| top_level_indices.get(root).copied());
+            let metrics_mode = metrics_config.mode_for(&column_path, top_level_index);
+            column_metrics_modes.insert(id, metrics_mode);
+
+            // Column sizes describe the file's physical layout rather than its
+            // values, so they are collected regardless of the metrics mode.
             column_sizes
                 .entry(id)
                 .and_modify(|x| *x += column.compressed_size())
                 .or_insert(column.compressed_size());
-            value_counts
-                .entry(id)
-                .and_modify(|x| *x += row_group.num_rows())
-                .or_insert(row_group.num_rows());
+            if metrics_mode.records_counts() {
+                value_counts
+                    .entry(id)
+                    .and_modify(|x| *x += row_group.num_rows())
+                    .or_insert(row_group.num_rows());
+            }
 
             if let Some(statistics) = column.statistics() {
-                if let Some(null_count) = statistics.null_count_opt() {
+                if let Some(null_count) = statistics
+                    .null_count_opt()
+                    .filter(|_| metrics_mode.records_counts())
+                {
                     null_value_counts
                         .entry(id)
                         .and_modify(|x| *x += null_count as i64)
@@ -116,7 +147,10 @@ pub fn parquet_to_datafile(
                     _ => None,
                 };
 
-                if let Some(distinct_counts) = distinct_counts.as_mut() {
+                if let Some(distinct_counts) = distinct_counts
+                    .as_mut()
+                    .filter(|_| metrics_mode.records_counts())
+                {
                     if let (Some(distinct_count), Some(min_bytes), Some(max_bytes)) = (
                         statistics.distinct_count_opt(),
                         statistics.min_bytes_opt(),
@@ -179,7 +213,10 @@ pub fn parquet_to_datafile(
                     }
                 }
 
-                if let Some(min_bytes) = statistics.min_bytes_opt() {
+                if let Some(min_bytes) = statistics
+                    .min_bytes_opt()
+                    .filter(|_| metrics_mode.records_bounds())
+                {
                     if let Type::Primitive(_) = &data_type {
                         let new = Value::try_from_bytes_with_hint(
                             min_bytes,
@@ -239,7 +276,10 @@ pub fn parquet_to_datafile(
                         }
                     }
                 }
-                if let Some(max_bytes) = statistics.max_bytes_opt() {
+                if let Some(max_bytes) = statistics
+                    .max_bytes_opt()
+                    .filter(|_| metrics_mode.records_bounds())
+                {
                     if let Type::Primitive(_) = &data_type {
                         let new = Value::try_from_bytes_with_hint(
                             max_bytes,
@@ -335,6 +375,28 @@ pub fn parquet_to_datafile(
             }
         }
     }
+    // Truncate once, after the bounds have been merged across row groups.
+    // Truncating per row group and merging afterwards would repeatedly widen an
+    // already-widened upper bound.
+    let lower_bounds = lower_bounds
+        .into_iter()
+        .map(|(id, value)| match column_metrics_modes.get(&id) {
+            Some(MetricsMode::Truncate(length)) => (id, truncate_lower_bound(value, *length)),
+            _ => (id, value),
+        })
+        .collect::<HashMap<i32, Value>>();
+    let upper_bounds = upper_bounds
+        .into_iter()
+        .filter_map(|(id, value)| match column_metrics_modes.get(&id) {
+            // A bound that cannot be raised is dropped: an understated upper
+            // bound would prune files that still hold matching rows.
+            Some(MetricsMode::Truncate(length)) => {
+                truncate_upper_bound(value, *length).map(|value| (id, value))
+            }
+            _ => Some((id, value)),
+        })
+        .collect::<HashMap<i32, Value>>();
+
     let mut builder = DataFile::builder();
     builder
         .with_content(if equality_ids.is_none() {
@@ -479,6 +541,162 @@ where
     };
 
     (outside_overlap + new_in_overlap).round() as i64
+}
+
+#[cfg(test)]
+mod metrics_mode_tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use arrow::array::{ArrayRef, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+    use arrow::record_batch::RecordBatch;
+    use iceberg_rust_spec::spec::schema::Schema;
+    use iceberg_rust_spec::spec::types::{PrimitiveType, StructField, Type};
+    use iceberg_rust_spec::spec::values::Value;
+    use iceberg_rust_spec::table_metadata::{
+        WRITE_METADATA_METRICS_COLUMN_PREFIX, WRITE_METADATA_METRICS_DEFAULT,
+    };
+    use parquet::arrow::ArrowWriter;
+    use parquet::file::reader::{FileReader, SerializedFileReader};
+
+    use super::parquet_to_datafile;
+
+    /// A two-column table whose values are far longer than any sane bound.
+    fn schema() -> Schema {
+        Schema::builder()
+            .with_struct_field(StructField {
+                id: 0,
+                name: "body".to_string(),
+                required: true,
+                field_type: Type::Primitive(PrimitiveType::String),
+                doc: None,
+                initial_default: None,
+                write_default: None,
+            })
+            .with_struct_field(StructField {
+                id: 1,
+                name: "trace_id".to_string(),
+                required: true,
+                field_type: Type::Primitive(PrimitiveType::String),
+                doc: None,
+                initial_default: None,
+                write_default: None,
+            })
+            .build()
+            .unwrap()
+    }
+
+    /// Writes one Parquet file holding `body`/`trace_id` and returns the
+    /// `DataFile` built from it under the given table properties.
+    fn datafile_with(
+        properties: HashMap<String, String>,
+    ) -> iceberg_rust_spec::spec::manifest::DataFile {
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("body", DataType::Utf8, false),
+            Field::new("trace_id", DataType::Utf8, false),
+        ]));
+
+        let bodies: ArrayRef = Arc::new(StringArray::from(vec![
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa- first log line",
+            "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz- last log line",
+        ]));
+        let trace_ids: ArrayRef = Arc::new(StringArray::from(vec![
+            "00000000000000000000000000000001",
+            "ffffffffffffffffffffffffffffffff",
+        ]));
+        let batch = RecordBatch::try_new(arrow_schema.clone(), vec![bodies, trace_ids]).unwrap();
+
+        let mut buffer = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buffer, arrow_schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        let file_size = buffer.len() as u64;
+
+        let reader = SerializedFileReader::new(bytes::Bytes::from(buffer)).unwrap();
+        let parquet_metadata = reader.metadata().clone();
+
+        parquet_to_datafile(
+            "/t/data/1.parquet",
+            file_size,
+            &parquet_metadata,
+            &schema(),
+            &[],
+            None,
+            &properties,
+        )
+        .unwrap()
+    }
+
+    fn bound(bounds: &Option<HashMap<i32, Value>>, id: i32) -> Option<String> {
+        match bounds.as_ref()?.get(&id)? {
+            Value::String(string) => Some(string.clone()),
+            other => panic!("expected a string bound, got {other:?}"),
+        }
+    }
+
+    /// A table that says nothing must still not carry a full-length bound for
+    /// every column: the spec's inferred default is `truncate(16)`.
+    #[test]
+    fn bounds_are_truncated_to_sixteen_by_default() {
+        let datafile = datafile_with(HashMap::new());
+
+        let lower = bound(datafile.lower_bounds(), 0).expect("a lower bound for body");
+        let upper = bound(datafile.upper_bounds(), 0).expect("an upper bound for body");
+
+        assert_eq!(lower.chars().count(), 16, "lower bound was not truncated");
+        assert!(upper.chars().count() <= 16, "upper bound was not truncated");
+
+        // Truncation must not break the bounds' meaning.
+        assert!(lower.as_str() <= "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa- first log line");
+        assert!(upper.as_str() >= "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz- last log line");
+    }
+
+    /// `none` on a column drops its bounds and counts, which is the point for a
+    /// JSON blob or a log body that no query ever prunes on.
+    #[test]
+    fn a_column_set_to_none_carries_no_metrics() {
+        let properties = HashMap::from([(
+            format!("{WRITE_METADATA_METRICS_COLUMN_PREFIX}body"),
+            "none".to_string(),
+        )]);
+        let datafile = datafile_with(properties);
+
+        assert_eq!(bound(datafile.lower_bounds(), 0), None);
+        assert_eq!(bound(datafile.upper_bounds(), 0), None);
+        assert_eq!(datafile.value_counts().as_ref().unwrap().get(&0), None);
+
+        // The other column is untouched.
+        assert!(bound(datafile.lower_bounds(), 1).is_some());
+        assert!(datafile.value_counts().as_ref().unwrap().get(&1).is_some());
+
+        // Column sizes describe layout, not values, and are always present.
+        assert!(datafile.column_sizes().as_ref().unwrap().get(&0).is_some());
+    }
+
+    /// `full` keeps the untruncated bound, for the columns worth it.
+    #[test]
+    fn a_column_set_to_full_keeps_untruncated_bounds() {
+        let properties = HashMap::from([
+            (
+                WRITE_METADATA_METRICS_DEFAULT.to_string(),
+                "counts".to_string(),
+            ),
+            (
+                format!("{WRITE_METADATA_METRICS_COLUMN_PREFIX}trace_id"),
+                "full".to_string(),
+            ),
+        ]);
+        let datafile = datafile_with(properties);
+
+        assert_eq!(
+            bound(datafile.lower_bounds(), 1).as_deref(),
+            Some("00000000000000000000000000000001")
+        );
+        // `counts` gives the other column counts but no bounds.
+        assert_eq!(bound(datafile.lower_bounds(), 0), None);
+        assert!(datafile.value_counts().as_ref().unwrap().get(&0).is_some());
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Bounds were collected for every column at full length. Since statistics live inline in the manifest entry for every data file, a table with a JSON blob or a log body carried two untruncated copies of its longest and shortest value on every entry, forever — to prune nothing.

Honors the spec's controls, with the four modes `none` / `counts` / `truncate(n)` / `full`:

| Property | Default |
|---|---|
| `write.metadata.metrics.default` | `truncate(16)` |
| `write.metadata.metrics.column.<name>` | — |
| `write.metadata.metrics.max-inferred-column-defaults` | `100` |

Resolution is per-column override → default → inferred default, and the inferred default only reaches the first `max-inferred-column-defaults` top-level columns.

Details worth a look:

- Truncation runs **once**, after bounds are merged across row groups. Per-row-group truncation would repeatedly widen an already-widened upper bound.
- Lower bounds truncate to a prefix (can only lower them). Upper bounds truncate then increment, so they still cover every value; when the prefix cannot be incremented the bound is **dropped** rather than understated — an understated upper bound prunes files that hold matching rows.
- String bounds truncate by character, never splitting one; increments skip the surrogate range.
- `column_sizes` describes layout rather than values, so it stays unconditional (matches the Java implementation).

**Behavior change:** the default becomes `truncate(16)` instead of full bounds. Set `write.metadata.metrics.default = "full"` to keep the old behavior.

Tests: 17 unit tests for parsing, resolution and truncation invariants, plus 3 end-to-end tests through `parquet_to_datafile` (default truncation, `none` dropping a column's metrics, `full` keeping untruncated bounds).