### PR TITLE
feat: honor the write.parquet.* writer properties

### DIFF
--- a/iceberg-rust-spec/src/spec/table_metadata.rs
+++ b/iceberg-rust-spec/src/spec/table_metadata.rs
@@ -68,6 +68,8 @@ pub const WRITE_PARQUET_DICT_SIZE_BYTES: &str = "write.parquet.dict-size-bytes";
 /// Maximum size of a Parquet row group in bytes. Row groups are flushed once
 /// their estimated encoded size crosses this, independent of row count.
 pub const WRITE_PARQUET_ROW_GROUP_SIZE_BYTES: &str = "write.parquet.row-group-size-bytes";
+/// Parquet page format: `v1` (DataPage) or `v2` (DataPageV2). Defaults to `v1`.
+pub const WRITE_PARQUET_PAGE_VERSION: &str = "write.parquet.page-version";
 /// Default statistics mode for a table's columns: `none`, `counts`,
 /// `truncate(n)` or `full`. Defaults to `truncate(16)`.
 pub const WRITE_METADATA_METRICS_DEFAULT: &str = "write.metadata.metrics.default";

--- a/iceberg-rust-spec/src/spec/table_metadata.rs
+++ b/iceberg-rust-spec/src/spec/table_metadata.rs
@@ -65,6 +65,9 @@ pub const WRITE_PARQUET_PAGE_SIZE_BYTES: &str = "write.parquet.page-size-bytes";
 pub const WRITE_PARQUET_PAGE_ROW_LIMIT: &str = "write.parquet.page-row-limit";
 /// Parquet dictionary page size in bytes.
 pub const WRITE_PARQUET_DICT_SIZE_BYTES: &str = "write.parquet.dict-size-bytes";
+/// Maximum size of a Parquet row group in bytes. Row groups are flushed once
+/// their estimated encoded size crosses this, independent of row count.
+pub const WRITE_PARQUET_ROW_GROUP_SIZE_BYTES: &str = "write.parquet.row-group-size-bytes";
 /// Default statistics mode for a table's columns: `none`, `counts`,
 /// `truncate(n)` or `full`. Defaults to `truncate(16)`.
 pub const WRITE_METADATA_METRICS_DEFAULT: &str = "write.metadata.metrics.default";

--- a/iceberg-rust-spec/src/spec/table_metadata.rs
+++ b/iceberg-rust-spec/src/spec/table_metadata.rs
@@ -53,6 +53,18 @@ pub const WRITE_METADATA_METRICS_DISTINCT_COUNTS_ENABLED: &str =
 /// `write.parquet.bloom-filter-enabled.column.label_env = "true"`.
 pub const WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX: &str =
     "write.parquet.bloom-filter-enabled.column.";
+/// Per-column Parquet bloom-filter false-positive probability: append the
+/// column name, e.g. `write.parquet.bloom-filter-fpp.column.trace_id = "0.01"`.
+/// A filter is sized from this, trading footer bytes against wasted reads.
+pub const WRITE_PARQUET_BLOOM_FILTER_FPP_COLUMN_PREFIX: &str =
+    "write.parquet.bloom-filter-fpp.column.";
+/// Parquet data page size in bytes. Bounds the granularity of page-level
+/// statistics and page skipping.
+pub const WRITE_PARQUET_PAGE_SIZE_BYTES: &str = "write.parquet.page-size-bytes";
+/// Maximum number of rows in a Parquet data page.
+pub const WRITE_PARQUET_PAGE_ROW_LIMIT: &str = "write.parquet.page-row-limit";
+/// Parquet dictionary page size in bytes.
+pub const WRITE_PARQUET_DICT_SIZE_BYTES: &str = "write.parquet.dict-size-bytes";
 /// Default statistics mode for a table's columns: `none`, `counts`,
 /// `truncate(n)` or `full`. Defaults to `truncate(16)`.
 pub const WRITE_METADATA_METRICS_DEFAULT: &str = "write.metadata.metrics.default";

--- a/iceberg-rust-spec/src/spec/table_metadata.rs
+++ b/iceberg-rust-spec/src/spec/table_metadata.rs
@@ -77,6 +77,12 @@ pub const WRITE_PARQUET_DICT_SIZE_BYTES: &str = "write.parquet.dict-size-bytes";
 /// `write.parquet.stats-enabled.column.body = "false"`. Distinct from
 /// `write.metadata.metrics.*`, which controls manifest-level stats.
 pub const WRITE_PARQUET_STATS_ENABLED_COLUMN_PREFIX: &str = "write.parquet.stats-enabled.column.";
+/// Per-column toggle for Parquet dictionary encoding: append the column
+/// name, e.g. `write.parquet.dict-encoding-enabled.column.trace_id =
+/// "false"`. Useful to turn off for a column whose values are rarely
+/// repeated, where a dictionary just adds overhead.
+pub const WRITE_PARQUET_DICT_ENCODING_ENABLED_COLUMN_PREFIX: &str =
+    "write.parquet.dict-encoding-enabled.column.";
 /// Maximum size of a Parquet row group in bytes. Row groups are flushed once
 /// their estimated encoded size crosses this, independent of row count.
 pub const WRITE_PARQUET_ROW_GROUP_SIZE_BYTES: &str = "write.parquet.row-group-size-bytes";

--- a/iceberg-rust-spec/src/spec/table_metadata.rs
+++ b/iceberg-rust-spec/src/spec/table_metadata.rs
@@ -72,6 +72,11 @@ pub const WRITE_PARQUET_PAGE_SIZE_BYTES: &str = "write.parquet.page-size-bytes";
 pub const WRITE_PARQUET_PAGE_ROW_LIMIT: &str = "write.parquet.page-row-limit";
 /// Parquet dictionary page size in bytes.
 pub const WRITE_PARQUET_DICT_SIZE_BYTES: &str = "write.parquet.dict-size-bytes";
+/// Per-column toggle for whether Parquet writes column statistics into the
+/// file footer: append the column name, e.g.
+/// `write.parquet.stats-enabled.column.body = "false"`. Distinct from
+/// `write.metadata.metrics.*`, which controls manifest-level stats.
+pub const WRITE_PARQUET_STATS_ENABLED_COLUMN_PREFIX: &str = "write.parquet.stats-enabled.column.";
 /// Maximum size of a Parquet row group in bytes. Row groups are flushed once
 /// their estimated encoded size crosses this, independent of row count.
 pub const WRITE_PARQUET_ROW_GROUP_SIZE_BYTES: &str = "write.parquet.row-group-size-bytes";

--- a/iceberg-rust-spec/src/spec/table_metadata.rs
+++ b/iceberg-rust-spec/src/spec/table_metadata.rs
@@ -58,6 +58,13 @@ pub const WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX: &str =
 /// A filter is sized from this, trading footer bytes against wasted reads.
 pub const WRITE_PARQUET_BLOOM_FILTER_FPP_COLUMN_PREFIX: &str =
     "write.parquet.bloom-filter-fpp.column.";
+/// Per-column Parquet bloom-filter expected number of distinct values:
+/// append the column name, e.g.
+/// `write.parquet.bloom-filter-ndv.column.trace_id = "1000000"`. A filter is
+/// sized from this and the fpp; without it, every column is sized as if it
+/// had the default cardinality regardless of how selective it actually is.
+pub const WRITE_PARQUET_BLOOM_FILTER_NDV_COLUMN_PREFIX: &str =
+    "write.parquet.bloom-filter-ndv.column.";
 /// Parquet data page size in bytes. Bounds the granularity of page-level
 /// statistics and page skipping.
 pub const WRITE_PARQUET_PAGE_SIZE_BYTES: &str = "write.parquet.page-size-bytes";

--- a/iceberg-rust/src/arrow/write.rs
+++ b/iceberg-rust/src/arrow/write.rs
@@ -55,6 +55,7 @@ use iceberg_rust_spec::{
         WRITE_PARQUET_BLOOM_FILTER_FPP_COLUMN_PREFIX, WRITE_PARQUET_COMPRESSION_CODEC,
         WRITE_PARQUET_COMPRESSION_LEVEL, WRITE_PARQUET_DICT_SIZE_BYTES,
         WRITE_PARQUET_PAGE_ROW_LIMIT, WRITE_PARQUET_PAGE_SIZE_BYTES,
+        WRITE_PARQUET_ROW_GROUP_SIZE_BYTES,
     },
     util::strip_prefix,
 };
@@ -584,9 +585,10 @@ fn column_path(column: &str) -> ColumnPath {
 ///
 /// Honors `write.parquet.compression-codec`,
 /// `write.parquet.compression-level`, `write.parquet.page-size-bytes`,
-/// `write.parquet.page-row-limit` and `write.parquet.dict-size-bytes`. An
-/// unparsable or unknown value is ignored, so a bad property degrades to the
-/// default instead of failing the write.
+/// `write.parquet.page-row-limit`, `write.parquet.dict-size-bytes` and
+/// `write.parquet.row-group-size-bytes`. An unparsable or unknown value is
+/// ignored, so a bad property degrades to the default instead of failing the
+/// write.
 fn apply_writer_properties(
     mut props_builder: parquet::file::properties::WriterPropertiesBuilder,
     table_properties: &HashMap<String, String>,
@@ -610,6 +612,9 @@ fn apply_writer_properties(
     }
     if let Some(bytes) = parse_positive(table_properties, WRITE_PARQUET_DICT_SIZE_BYTES) {
         props_builder = props_builder.set_dictionary_page_size_limit(bytes);
+    }
+    if let Some(bytes) = parse_positive(table_properties, WRITE_PARQUET_ROW_GROUP_SIZE_BYTES) {
+        props_builder = props_builder.set_max_row_group_bytes(Some(bytes));
     }
 
     props_builder
@@ -832,6 +837,24 @@ mod writer_properties_tests {
         assert_eq!(props.data_page_size_limit(), 65536);
         assert_eq!(props.data_page_row_count_limit(), 5000);
         assert_eq!(props.dictionary_page_size_limit(), 131072);
+    }
+
+    /// `set_max_row_group_bytes` flushes a row group by estimated encoded
+    /// size rather than row count, unlike the row-count-only knob it
+    /// complements.
+    #[test]
+    fn row_group_size_bytes_is_honored() {
+        let props = build(&[(WRITE_PARQUET_ROW_GROUP_SIZE_BYTES, "268435456")]);
+        assert_eq!(props.max_row_group_bytes(), Some(268435456));
+
+        for value in ["not-a-number", "0"] {
+            let props = build(&[(WRITE_PARQUET_ROW_GROUP_SIZE_BYTES, value)]);
+            assert_eq!(
+                props.max_row_group_bytes(),
+                None,
+                "row group size {value:?} should have been ignored"
+            );
+        }
     }
 
     /// A bloom filter is sized from its target false-positive rate, so a

--- a/iceberg-rust/src/arrow/write.rs
+++ b/iceberg-rust/src/arrow/write.rs
@@ -22,8 +22,9 @@
 //! ```no_run
 //! # use arrow::record_batch::RecordBatch;
 //! # use futures::Stream;
+//! # use iceberg_rust::arrow::write::write_parquet_partitioned;
 //! # use iceberg_rust::table::Table;
-//! # async fn example(table: &Table, batches: impl Stream<Item = Result<RecordBatch, arrow::error::ArrowError>>) {
+//! # async fn example(table: &Table, batches: impl Stream<Item = Result<RecordBatch, arrow::error::ArrowError>> + Send + 'static) {
 //! let data_files = write_parquet_partitioned(
 //!     table,
 //!     batches,

--- a/iceberg-rust/src/arrow/write.rs
+++ b/iceberg-rust/src/arrow/write.rs
@@ -54,9 +54,9 @@ use iceberg_rust_spec::{
         WRITE_OBJECT_STORAGE_ENABLED, WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX,
         WRITE_PARQUET_BLOOM_FILTER_FPP_COLUMN_PREFIX, WRITE_PARQUET_BLOOM_FILTER_NDV_COLUMN_PREFIX,
         WRITE_PARQUET_COMPRESSION_CODEC, WRITE_PARQUET_COMPRESSION_LEVEL,
-        WRITE_PARQUET_DICT_SIZE_BYTES, WRITE_PARQUET_PAGE_ROW_LIMIT, WRITE_PARQUET_PAGE_SIZE_BYTES,
-        WRITE_PARQUET_PAGE_VERSION, WRITE_PARQUET_ROW_GROUP_SIZE_BYTES,
-        WRITE_PARQUET_STATS_ENABLED_COLUMN_PREFIX,
+        WRITE_PARQUET_DICT_ENCODING_ENABLED_COLUMN_PREFIX, WRITE_PARQUET_DICT_SIZE_BYTES,
+        WRITE_PARQUET_PAGE_ROW_LIMIT, WRITE_PARQUET_PAGE_SIZE_BYTES, WRITE_PARQUET_PAGE_VERSION,
+        WRITE_PARQUET_ROW_GROUP_SIZE_BYTES, WRITE_PARQUET_STATS_ENABLED_COLUMN_PREFIX,
     },
     util::strip_prefix,
 };
@@ -527,7 +527,7 @@ async fn create_arrow_writer(
     ));
     props_builder = apply_writer_properties(props_builder, table_properties);
     props_builder = apply_bloom_filter_properties(props_builder, table_properties);
-    props_builder = apply_column_statistics_properties(props_builder, table_properties);
+    props_builder = apply_column_write_properties(props_builder, table_properties);
     if estimate_distinct_count {
         props_builder = props_builder.set_key_value_metadata(Some(vec![KeyValue::new(
             ICEBERG_ESTIMATE_INT64_DISTINCT_COUNT_META_KEY.to_owned(),
@@ -591,13 +591,15 @@ fn column_path(column: &str) -> ColumnPath {
     ColumnPath::from(column.split('.').map(String::from).collect::<Vec<String>>())
 }
 
-/// Applies per-column Parquet statistics table properties to the writer.
+/// Applies per-column Parquet write-behavior table properties to the writer.
 ///
 /// Honors `write.parquet.stats-enabled.column.<name>` = `true`/`false`,
 /// controlling whether Parquet writes column statistics into the file
-/// footer for that column. This is distinct from `write.metadata.metrics.*`,
-/// which controls the truncated stats recorded in the Iceberg manifest.
-fn apply_column_statistics_properties(
+/// footer for that column (distinct from `write.metadata.metrics.*`, which
+/// controls the truncated stats recorded in the Iceberg manifest), and
+/// `write.parquet.dict-encoding-enabled.column.<name>` = `true`/`false`,
+/// controlling whether that column uses dictionary encoding.
+fn apply_column_write_properties(
     mut props_builder: parquet::file::properties::WriterPropertiesBuilder,
     table_properties: &HashMap<String, String>,
 ) -> parquet::file::properties::WriterPropertiesBuilder {
@@ -610,6 +612,12 @@ fn apply_column_statistics_properties(
             };
             props_builder =
                 props_builder.set_column_statistics_enabled(column_path(column), enabled);
+        } else if let Some(column) =
+            key.strip_prefix(WRITE_PARQUET_DICT_ENCODING_ENABLED_COLUMN_PREFIX)
+        {
+            let enabled = value.eq_ignore_ascii_case("true");
+            props_builder =
+                props_builder.set_column_dictionary_enabled(column_path(column), enabled);
         }
     }
     props_builder
@@ -1049,8 +1057,7 @@ mod writer_properties_tests {
             format!("{WRITE_PARQUET_STATS_ENABLED_COLUMN_PREFIX}body"),
             "false".to_string(),
         )]);
-        let props =
-            apply_column_statistics_properties(WriterProperties::builder(), &properties).build();
+        let props = apply_column_write_properties(WriterProperties::builder(), &properties).build();
 
         assert_eq!(
             props.statistics_enabled(&ColumnPath::from("body")),
@@ -1066,12 +1073,33 @@ mod writer_properties_tests {
             format!("{WRITE_PARQUET_STATS_ENABLED_COLUMN_PREFIX}body"),
             "true".to_string(),
         )]);
-        let props =
-            apply_column_statistics_properties(WriterProperties::builder(), &properties).build();
+        let props = apply_column_write_properties(WriterProperties::builder(), &properties).build();
         assert_eq!(
             props.statistics_enabled(&ColumnPath::from("body")),
             EnabledStatistics::Page
         );
+    }
+
+    /// Turning dictionary encoding off is useful for a column whose values
+    /// are rarely repeated, where a dictionary just adds overhead.
+    #[test]
+    fn column_dictionary_encoding_is_honored() {
+        let properties: HashMap<String, String> = HashMap::from([(
+            format!("{WRITE_PARQUET_DICT_ENCODING_ENABLED_COLUMN_PREFIX}trace_id"),
+            "false".to_string(),
+        )]);
+        let props = apply_column_write_properties(WriterProperties::builder(), &properties).build();
+
+        assert!(!props.dictionary_enabled(&ColumnPath::from("trace_id")));
+        // An untouched column keeps the builder's default (enabled).
+        assert!(props.dictionary_enabled(&ColumnPath::from("other")));
+
+        let properties: HashMap<String, String> = HashMap::from([(
+            format!("{WRITE_PARQUET_DICT_ENCODING_ENABLED_COLUMN_PREFIX}trace_id"),
+            "true".to_string(),
+        )]);
+        let props = apply_column_write_properties(WriterProperties::builder(), &properties).build();
+        assert!(props.dictionary_enabled(&ColumnPath::from("trace_id")));
     }
 }
 

--- a/iceberg-rust/src/arrow/write.rs
+++ b/iceberg-rust/src/arrow/write.rs
@@ -52,12 +52,15 @@ use iceberg_rust_spec::{
     table_metadata::{
         self, WRITE_DATA_PATH, WRITE_METADATA_METRICS_DISTINCT_COUNTS_ENABLED,
         WRITE_OBJECT_STORAGE_ENABLED, WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX,
+        WRITE_PARQUET_BLOOM_FILTER_FPP_COLUMN_PREFIX, WRITE_PARQUET_COMPRESSION_CODEC,
+        WRITE_PARQUET_COMPRESSION_LEVEL, WRITE_PARQUET_DICT_SIZE_BYTES,
+        WRITE_PARQUET_PAGE_ROW_LIMIT, WRITE_PARQUET_PAGE_SIZE_BYTES,
     },
     util::strip_prefix,
 };
 use parquet::{
     arrow::AsyncArrowWriter,
-    basic::{Compression, ZstdLevel},
+    basic::{BrotliLevel, Compression, GzipLevel, ZstdLevel},
     file::{
         metadata::{KeyValue, ParquetMetaData},
         properties::WriterProperties,
@@ -77,6 +80,10 @@ use super::partition::partition_record_batch;
 
 const MAX_PARQUET_SIZE: usize = 512_000_000;
 const COMPRESSION_FACTOR: usize = 200;
+
+/// Zstd level used when the table names zstd without a level, and the level
+/// the writer falls back to when a table says nothing about compression.
+const DEFAULT_ZSTD_LEVEL_VALUE: i32 = 1;
 
 #[instrument(skip(table, batches), fields(table_name = %table.identifier().name()))]
 /// Writes Arrow record batches as partitioned Parquet files.
@@ -513,8 +520,10 @@ async fn create_arrow_writer(
         .get(WRITE_METADATA_METRICS_DISTINCT_COUNTS_ENABLED)
         .is_some_and(|x| x == "true");
 
-    let mut props_builder =
-        WriterProperties::builder().set_compression(Compression::ZSTD(ZstdLevel::try_new(1)?));
+    let mut props_builder = WriterProperties::builder().set_compression(Compression::ZSTD(
+        ZstdLevel::try_new(DEFAULT_ZSTD_LEVEL_VALUE)?,
+    ));
+    props_builder = apply_writer_properties(props_builder, table_properties);
     props_builder = apply_bloom_filter_properties(props_builder, table_properties);
     if estimate_distinct_count {
         props_builder = props_builder.set_key_value_metadata(Some(vec![KeyValue::new(
@@ -535,9 +544,10 @@ async fn create_arrow_writer(
 
 /// Applies per-column bloom-filter table properties to the writer builder.
 ///
-/// Honors the standard Iceberg property
-/// `write.parquet.bloom-filter-enabled.column.<name>` = `true`/`false`
-/// per column. Unrelated properties are ignored.
+/// Honors the standard Iceberg properties
+/// `write.parquet.bloom-filter-enabled.column.<name>` = `true`/`false` and
+/// `write.parquet.bloom-filter-fpp.column.<name>` = a false-positive
+/// probability in `(0, 1)`. Unrelated properties are ignored.
 fn apply_bloom_filter_properties(
     mut props_builder: parquet::file::properties::WriterPropertiesBuilder,
     table_properties: &HashMap<String, String>,
@@ -545,15 +555,103 @@ fn apply_bloom_filter_properties(
     for (key, value) in table_properties {
         if let Some(column) = key.strip_prefix(WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX) {
             let enabled = value.eq_ignore_ascii_case("true");
-            // Parquet addresses nested columns by path parts; a dotted name
-            // passed as one string would be treated as a single segment and
-            // silently never match.
-            let path_parts: Vec<String> = column.split('.').map(String::from).collect();
-            props_builder = props_builder
-                .set_column_bloom_filter_enabled(ColumnPath::from(path_parts), enabled);
+            props_builder =
+                props_builder.set_column_bloom_filter_enabled(column_path(column), enabled);
+        } else if let Some(column) = key.strip_prefix(WRITE_PARQUET_BLOOM_FILTER_FPP_COLUMN_PREFIX)
+        {
+            // A filter is sized from its target false-positive rate, so an
+            // out-of-range value would produce a nonsensical filter. Ignore it
+            // and keep the default rather than fail the write.
+            if let Some(fpp) = value
+                .parse::<f64>()
+                .ok()
+                .filter(|fpp| *fpp > 0.0 && *fpp < 1.0)
+            {
+                props_builder = props_builder.set_column_bloom_filter_fpp(column_path(column), fpp);
+            }
         }
     }
     props_builder
+}
+
+/// Parquet addresses nested columns by path parts; a dotted name passed as one
+/// string would be treated as a single segment and silently never match.
+fn column_path(column: &str) -> ColumnPath {
+    ColumnPath::from(column.split('.').map(String::from).collect::<Vec<String>>())
+}
+
+/// Applies the file-layout and compression table properties to the writer.
+///
+/// Honors `write.parquet.compression-codec`,
+/// `write.parquet.compression-level`, `write.parquet.page-size-bytes`,
+/// `write.parquet.page-row-limit` and `write.parquet.dict-size-bytes`. An
+/// unparsable or unknown value is ignored, so a bad property degrades to the
+/// default instead of failing the write.
+fn apply_writer_properties(
+    mut props_builder: parquet::file::properties::WriterPropertiesBuilder,
+    table_properties: &HashMap<String, String>,
+) -> parquet::file::properties::WriterPropertiesBuilder {
+    let level = table_properties
+        .get(WRITE_PARQUET_COMPRESSION_LEVEL)
+        .and_then(|value| value.parse::<u32>().ok());
+
+    if let Some(codec) = table_properties
+        .get(WRITE_PARQUET_COMPRESSION_CODEC)
+        .and_then(|codec| compression_from(codec, level))
+    {
+        props_builder = props_builder.set_compression(codec);
+    }
+
+    if let Some(bytes) = parse_positive(table_properties, WRITE_PARQUET_PAGE_SIZE_BYTES) {
+        props_builder = props_builder.set_data_page_size_limit(bytes);
+    }
+    if let Some(rows) = parse_positive(table_properties, WRITE_PARQUET_PAGE_ROW_LIMIT) {
+        props_builder = props_builder.set_data_page_row_count_limit(rows);
+    }
+    if let Some(bytes) = parse_positive(table_properties, WRITE_PARQUET_DICT_SIZE_BYTES) {
+        props_builder = props_builder.set_dictionary_page_size_limit(bytes);
+    }
+
+    props_builder
+}
+
+fn parse_positive(table_properties: &HashMap<String, String>, key: &str) -> Option<usize> {
+    table_properties
+        .get(key)
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+}
+
+/// Resolve an Iceberg codec name, with its optional level, to a Parquet codec.
+///
+/// Returns `None` for an unknown codec so the caller keeps its default. A level
+/// the codec rejects falls back to that codec's default level rather than
+/// dropping the codec entirely.
+fn compression_from(codec: &str, level: Option<u32>) -> Option<Compression> {
+    match codec.trim().to_ascii_lowercase().as_str() {
+        "uncompressed" | "none" => Some(Compression::UNCOMPRESSED),
+        "snappy" => Some(Compression::SNAPPY),
+        "lz4" => Some(Compression::LZ4),
+        "lz4_raw" => Some(Compression::LZ4_RAW),
+        "gzip" => Some(Compression::GZIP(
+            level
+                .and_then(|level| GzipLevel::try_new(level).ok())
+                .unwrap_or_default(),
+        )),
+        "brotli" => Some(Compression::BROTLI(
+            level
+                .and_then(|level| BrotliLevel::try_new(level).ok())
+                .unwrap_or_default(),
+        )),
+        "zstd" => Some(Compression::ZSTD(
+            level
+                .and_then(|level| ZstdLevel::try_new(level as i32).ok())
+                .unwrap_or_else(|| {
+                    ZstdLevel::try_new(DEFAULT_ZSTD_LEVEL_VALUE).unwrap_or_default()
+                }),
+        )),
+        _ => None,
+    }
 }
 
 /// Generates a unique file path for a Parquet data file.
@@ -635,6 +733,160 @@ fn record_batch_size(batch: &RecordBatch) -> usize {
         .iter()
         .fold(0, |acc, x| acc + x.size())
         * batch.num_rows()
+}
+
+#[cfg(test)]
+mod writer_properties_tests {
+    use super::*;
+
+    fn build(properties: &[(&str, &str)]) -> parquet::file::properties::WriterProperties {
+        let properties: HashMap<String, String> = properties
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect();
+        apply_writer_properties(WriterProperties::builder(), &properties).build()
+    }
+
+    /// A table naming a codec must get it. The writer previously hardcoded
+    /// zstd level 1 while table creation recorded `zstd`/`3` in the metadata,
+    /// so the properties described a file that was never written.
+    #[test]
+    fn the_compression_codec_and_level_are_honored() {
+        let props = build(&[
+            (WRITE_PARQUET_COMPRESSION_CODEC, "zstd"),
+            (WRITE_PARQUET_COMPRESSION_LEVEL, "9"),
+        ]);
+        assert_eq!(
+            props.compression(&ColumnPath::from("any")),
+            Compression::ZSTD(ZstdLevel::try_new(9).unwrap())
+        );
+
+        assert_eq!(
+            build(&[(WRITE_PARQUET_COMPRESSION_CODEC, "SNAPPY")])
+                .compression(&ColumnPath::from("any")),
+            Compression::SNAPPY
+        );
+        assert_eq!(
+            build(&[(WRITE_PARQUET_COMPRESSION_CODEC, "uncompressed")])
+                .compression(&ColumnPath::from("any")),
+            Compression::UNCOMPRESSED
+        );
+    }
+
+    /// A codec that takes no level must ignore one rather than be dropped.
+    #[test]
+    fn a_level_on_a_levelless_codec_is_ignored() {
+        let props = build(&[
+            (WRITE_PARQUET_COMPRESSION_CODEC, "snappy"),
+            (WRITE_PARQUET_COMPRESSION_LEVEL, "9"),
+        ]);
+        assert_eq!(
+            props.compression(&ColumnPath::from("any")),
+            Compression::SNAPPY
+        );
+    }
+
+    /// A bad property must degrade to the default, never fail the write.
+    #[test]
+    fn unusable_values_fall_back_to_defaults() {
+        let default = WriterProperties::builder().build();
+
+        // Unknown codec: keep whatever the builder had.
+        let props = build(&[(WRITE_PARQUET_COMPRESSION_CODEC, "rot13")]);
+        assert_eq!(
+            props.compression(&ColumnPath::from("any")),
+            default.compression(&ColumnPath::from("any"))
+        );
+
+        // Out-of-range zstd level: keep the codec, use its default level.
+        let props = build(&[
+            (WRITE_PARQUET_COMPRESSION_CODEC, "zstd"),
+            (WRITE_PARQUET_COMPRESSION_LEVEL, "999"),
+        ]);
+        assert!(matches!(
+            props.compression(&ColumnPath::from("any")),
+            Compression::ZSTD(_)
+        ));
+
+        // Unparsable and zero sizes are ignored.
+        for value in ["not-a-number", "0"] {
+            let props = build(&[(WRITE_PARQUET_PAGE_SIZE_BYTES, value)]);
+            assert_eq!(
+                props.data_page_size_limit(),
+                default.data_page_size_limit(),
+                "page size {value:?} should have been ignored"
+            );
+        }
+    }
+
+    /// Page and dictionary sizing bound how finely a reader can skip within a
+    /// file, and were not reachable at all before.
+    #[test]
+    fn page_and_dictionary_sizing_are_honored() {
+        let props = build(&[
+            (WRITE_PARQUET_PAGE_SIZE_BYTES, "65536"),
+            (WRITE_PARQUET_PAGE_ROW_LIMIT, "5000"),
+            (WRITE_PARQUET_DICT_SIZE_BYTES, "131072"),
+        ]);
+
+        assert_eq!(props.data_page_size_limit(), 65536);
+        assert_eq!(props.data_page_row_count_limit(), 5000);
+        assert_eq!(props.dictionary_page_size_limit(), 131072);
+    }
+
+    /// A bloom filter is sized from its target false-positive rate, so a
+    /// high-cardinality column such as `trace_id` needs its own.
+    #[test]
+    fn per_column_bloom_filter_fpp_is_honored() {
+        let properties: HashMap<String, String> = HashMap::from([
+            (
+                format!("{WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX}trace_id"),
+                "true".to_string(),
+            ),
+            (
+                format!("{WRITE_PARQUET_BLOOM_FILTER_FPP_COLUMN_PREFIX}trace_id"),
+                "0.001".to_string(),
+            ),
+        ]);
+        let props = apply_bloom_filter_properties(WriterProperties::builder(), &properties).build();
+
+        assert_eq!(
+            props.bloom_filter_properties(&ColumnPath::from("trace_id")),
+            Some(&parquet::file::properties::BloomFilterProperties {
+                fpp: 0.001,
+                ndv: parquet::file::properties::DEFAULT_BLOOM_FILTER_NDV,
+            })
+        );
+    }
+
+    /// An fpp outside `(0, 1)` cannot size a filter; it must be ignored rather
+    /// than produce a nonsensical one.
+    #[test]
+    fn an_out_of_range_fpp_is_ignored() {
+        for value in ["0", "1", "-0.5", "1.5", "many"] {
+            let properties: HashMap<String, String> = HashMap::from([
+                (
+                    format!("{WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX}trace_id"),
+                    "true".to_string(),
+                ),
+                (
+                    format!("{WRITE_PARQUET_BLOOM_FILTER_FPP_COLUMN_PREFIX}trace_id"),
+                    value.to_string(),
+                ),
+            ]);
+            let props =
+                apply_bloom_filter_properties(WriterProperties::builder(), &properties).build();
+
+            let fpp = props
+                .bloom_filter_properties(&ColumnPath::from("trace_id"))
+                .map(|properties| properties.fpp);
+            assert_eq!(
+                fpp,
+                Some(parquet::file::properties::DEFAULT_BLOOM_FILTER_FPP),
+                "fpp {value:?} should have been ignored"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/iceberg-rust/src/arrow/write.rs
+++ b/iceberg-rust/src/arrow/write.rs
@@ -54,7 +54,7 @@ use iceberg_rust_spec::{
         WRITE_OBJECT_STORAGE_ENABLED, WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX,
         WRITE_PARQUET_BLOOM_FILTER_FPP_COLUMN_PREFIX, WRITE_PARQUET_COMPRESSION_CODEC,
         WRITE_PARQUET_COMPRESSION_LEVEL, WRITE_PARQUET_DICT_SIZE_BYTES,
-        WRITE_PARQUET_PAGE_ROW_LIMIT, WRITE_PARQUET_PAGE_SIZE_BYTES,
+        WRITE_PARQUET_PAGE_ROW_LIMIT, WRITE_PARQUET_PAGE_SIZE_BYTES, WRITE_PARQUET_PAGE_VERSION,
         WRITE_PARQUET_ROW_GROUP_SIZE_BYTES,
     },
     util::strip_prefix,
@@ -64,7 +64,7 @@ use parquet::{
     basic::{BrotliLevel, Compression, GzipLevel, ZstdLevel},
     file::{
         metadata::{KeyValue, ParquetMetaData},
-        properties::WriterProperties,
+        properties::{WriterProperties, WriterVersion},
     },
     schema::types::ColumnPath,
 };
@@ -585,10 +585,10 @@ fn column_path(column: &str) -> ColumnPath {
 ///
 /// Honors `write.parquet.compression-codec`,
 /// `write.parquet.compression-level`, `write.parquet.page-size-bytes`,
-/// `write.parquet.page-row-limit`, `write.parquet.dict-size-bytes` and
-/// `write.parquet.row-group-size-bytes`. An unparsable or unknown value is
-/// ignored, so a bad property degrades to the default instead of failing the
-/// write.
+/// `write.parquet.page-row-limit`, `write.parquet.dict-size-bytes`,
+/// `write.parquet.row-group-size-bytes` and `write.parquet.page-version`. An
+/// unparsable or unknown value is ignored, so a bad property degrades to the
+/// default instead of failing the write.
 fn apply_writer_properties(
     mut props_builder: parquet::file::properties::WriterPropertiesBuilder,
     table_properties: &HashMap<String, String>,
@@ -616,8 +616,27 @@ fn apply_writer_properties(
     if let Some(bytes) = parse_positive(table_properties, WRITE_PARQUET_ROW_GROUP_SIZE_BYTES) {
         props_builder = props_builder.set_max_row_group_bytes(Some(bytes));
     }
+    if let Some(version) = table_properties
+        .get(WRITE_PARQUET_PAGE_VERSION)
+        .and_then(|version| writer_version_from(version))
+    {
+        props_builder = props_builder.set_writer_version(version);
+    }
 
     props_builder
+}
+
+/// Resolve an Iceberg page-version name to a Parquet writer version.
+///
+/// Returns `None` for anything other than `v1`/`v2` so the caller keeps
+/// whatever the builder had, matching the reference implementation's default
+/// of `v1`.
+fn writer_version_from(version: &str) -> Option<WriterVersion> {
+    match version.trim().to_ascii_lowercase().as_str() {
+        "v1" => Some(WriterVersion::PARQUET_1_0),
+        "v2" => Some(WriterVersion::PARQUET_2_0),
+        _ => None,
+    }
 }
 
 fn parse_positive(table_properties: &HashMap<String, String>, key: &str) -> Option<usize> {
@@ -855,6 +874,27 @@ mod writer_properties_tests {
                 "row group size {value:?} should have been ignored"
             );
         }
+    }
+
+    /// `v2` unlocks DataPageV2 encoding; an unrecognized value must keep the
+    /// builder's default (`v1`) rather than fail the write.
+    #[test]
+    fn page_version_is_honored() {
+        assert_eq!(
+            build(&[(WRITE_PARQUET_PAGE_VERSION, "v2")]).writer_version(),
+            WriterVersion::PARQUET_2_0
+        );
+        assert_eq!(
+            build(&[(WRITE_PARQUET_PAGE_VERSION, "V1")]).writer_version(),
+            WriterVersion::PARQUET_1_0
+        );
+
+        let default = WriterProperties::builder().build();
+        assert_eq!(
+            build(&[(WRITE_PARQUET_PAGE_VERSION, "v3")]).writer_version(),
+            default.writer_version(),
+            "an unrecognized page version should have been ignored"
+        );
     }
 
     /// A bloom filter is sized from its target false-positive rate, so a

--- a/iceberg-rust/src/arrow/write.rs
+++ b/iceberg-rust/src/arrow/write.rs
@@ -56,6 +56,7 @@ use iceberg_rust_spec::{
         WRITE_PARQUET_COMPRESSION_CODEC, WRITE_PARQUET_COMPRESSION_LEVEL,
         WRITE_PARQUET_DICT_SIZE_BYTES, WRITE_PARQUET_PAGE_ROW_LIMIT, WRITE_PARQUET_PAGE_SIZE_BYTES,
         WRITE_PARQUET_PAGE_VERSION, WRITE_PARQUET_ROW_GROUP_SIZE_BYTES,
+        WRITE_PARQUET_STATS_ENABLED_COLUMN_PREFIX,
     },
     util::strip_prefix,
 };
@@ -64,7 +65,7 @@ use parquet::{
     basic::{BrotliLevel, Compression, GzipLevel, ZstdLevel},
     file::{
         metadata::{KeyValue, ParquetMetaData},
-        properties::{WriterProperties, WriterVersion},
+        properties::{EnabledStatistics, WriterProperties, WriterVersion},
     },
     schema::types::ColumnPath,
 };
@@ -526,6 +527,7 @@ async fn create_arrow_writer(
     ));
     props_builder = apply_writer_properties(props_builder, table_properties);
     props_builder = apply_bloom_filter_properties(props_builder, table_properties);
+    props_builder = apply_column_statistics_properties(props_builder, table_properties);
     if estimate_distinct_count {
         props_builder = props_builder.set_key_value_metadata(Some(vec![KeyValue::new(
             ICEBERG_ESTIMATE_INT64_DISTINCT_COUNT_META_KEY.to_owned(),
@@ -587,6 +589,30 @@ fn apply_bloom_filter_properties(
 /// string would be treated as a single segment and silently never match.
 fn column_path(column: &str) -> ColumnPath {
     ColumnPath::from(column.split('.').map(String::from).collect::<Vec<String>>())
+}
+
+/// Applies per-column Parquet statistics table properties to the writer.
+///
+/// Honors `write.parquet.stats-enabled.column.<name>` = `true`/`false`,
+/// controlling whether Parquet writes column statistics into the file
+/// footer for that column. This is distinct from `write.metadata.metrics.*`,
+/// which controls the truncated stats recorded in the Iceberg manifest.
+fn apply_column_statistics_properties(
+    mut props_builder: parquet::file::properties::WriterPropertiesBuilder,
+    table_properties: &HashMap<String, String>,
+) -> parquet::file::properties::WriterPropertiesBuilder {
+    for (key, value) in table_properties {
+        if let Some(column) = key.strip_prefix(WRITE_PARQUET_STATS_ENABLED_COLUMN_PREFIX) {
+            let enabled = if value.eq_ignore_ascii_case("true") {
+                EnabledStatistics::Page
+            } else {
+                EnabledStatistics::None
+            };
+            props_builder =
+                props_builder.set_column_statistics_enabled(column_path(column), enabled);
+        }
+    }
+    props_builder
 }
 
 /// Applies the file-layout and compression table properties to the writer.
@@ -1012,6 +1038,40 @@ mod writer_properties_tests {
                 "fpp {value:?} should have been ignored"
             );
         }
+    }
+
+    /// Distinct from `write.metadata.metrics.*`: this toggles whether
+    /// Parquet itself writes column stats into the file footer, defaulting
+    /// to on (`EnabledStatistics::Page`).
+    #[test]
+    fn column_statistics_enabled_is_honored() {
+        let properties: HashMap<String, String> = HashMap::from([(
+            format!("{WRITE_PARQUET_STATS_ENABLED_COLUMN_PREFIX}body"),
+            "false".to_string(),
+        )]);
+        let props =
+            apply_column_statistics_properties(WriterProperties::builder(), &properties).build();
+
+        assert_eq!(
+            props.statistics_enabled(&ColumnPath::from("body")),
+            EnabledStatistics::None
+        );
+        // An untouched column keeps the builder's default.
+        assert_eq!(
+            props.statistics_enabled(&ColumnPath::from("other")),
+            EnabledStatistics::Page
+        );
+
+        let properties: HashMap<String, String> = HashMap::from([(
+            format!("{WRITE_PARQUET_STATS_ENABLED_COLUMN_PREFIX}body"),
+            "true".to_string(),
+        )]);
+        let props =
+            apply_column_statistics_properties(WriterProperties::builder(), &properties).build();
+        assert_eq!(
+            props.statistics_enabled(&ColumnPath::from("body")),
+            EnabledStatistics::Page
+        );
     }
 }
 

--- a/iceberg-rust/src/arrow/write.rs
+++ b/iceberg-rust/src/arrow/write.rs
@@ -52,10 +52,10 @@ use iceberg_rust_spec::{
     table_metadata::{
         self, WRITE_DATA_PATH, WRITE_METADATA_METRICS_DISTINCT_COUNTS_ENABLED,
         WRITE_OBJECT_STORAGE_ENABLED, WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX,
-        WRITE_PARQUET_BLOOM_FILTER_FPP_COLUMN_PREFIX, WRITE_PARQUET_COMPRESSION_CODEC,
-        WRITE_PARQUET_COMPRESSION_LEVEL, WRITE_PARQUET_DICT_SIZE_BYTES,
-        WRITE_PARQUET_PAGE_ROW_LIMIT, WRITE_PARQUET_PAGE_SIZE_BYTES, WRITE_PARQUET_PAGE_VERSION,
-        WRITE_PARQUET_ROW_GROUP_SIZE_BYTES,
+        WRITE_PARQUET_BLOOM_FILTER_FPP_COLUMN_PREFIX, WRITE_PARQUET_BLOOM_FILTER_NDV_COLUMN_PREFIX,
+        WRITE_PARQUET_COMPRESSION_CODEC, WRITE_PARQUET_COMPRESSION_LEVEL,
+        WRITE_PARQUET_DICT_SIZE_BYTES, WRITE_PARQUET_PAGE_ROW_LIMIT, WRITE_PARQUET_PAGE_SIZE_BYTES,
+        WRITE_PARQUET_PAGE_VERSION, WRITE_PARQUET_ROW_GROUP_SIZE_BYTES,
     },
     util::strip_prefix,
 };
@@ -546,9 +546,10 @@ async fn create_arrow_writer(
 /// Applies per-column bloom-filter table properties to the writer builder.
 ///
 /// Honors the standard Iceberg properties
-/// `write.parquet.bloom-filter-enabled.column.<name>` = `true`/`false` and
+/// `write.parquet.bloom-filter-enabled.column.<name>` = `true`/`false`,
 /// `write.parquet.bloom-filter-fpp.column.<name>` = a false-positive
-/// probability in `(0, 1)`. Unrelated properties are ignored.
+/// probability in `(0, 1)` and `write.parquet.bloom-filter-ndv.column.<name>`
+/// = an expected distinct-value count > 0. Unrelated properties are ignored.
 fn apply_bloom_filter_properties(
     mut props_builder: parquet::file::properties::WriterPropertiesBuilder,
     table_properties: &HashMap<String, String>,
@@ -569,6 +570,13 @@ fn apply_bloom_filter_properties(
                 .filter(|fpp| *fpp > 0.0 && *fpp < 1.0)
             {
                 props_builder = props_builder.set_column_bloom_filter_fpp(column_path(column), fpp);
+            }
+        } else if let Some(column) = key.strip_prefix(WRITE_PARQUET_BLOOM_FILTER_NDV_COLUMN_PREFIX)
+        {
+            // A zero or negative ndv can't size a filter; ignore it and keep
+            // the default rather than fail the write.
+            if let Some(ndv) = value.parse::<u64>().ok().filter(|ndv| *ndv > 0) {
+                props_builder = props_builder.set_column_bloom_filter_ndv(column_path(column), ndv);
             }
         }
     }
@@ -920,6 +928,61 @@ mod writer_properties_tests {
                 ndv: parquet::file::properties::DEFAULT_BLOOM_FILTER_NDV,
             })
         );
+    }
+
+    /// The fpp alone assumes the default cardinality; a high-cardinality
+    /// column such as `trace_id` needs its real ndv to size the filter
+    /// correctly.
+    #[test]
+    fn per_column_bloom_filter_ndv_is_honored() {
+        let properties: HashMap<String, String> = HashMap::from([
+            (
+                format!("{WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX}trace_id"),
+                "true".to_string(),
+            ),
+            (
+                format!("{WRITE_PARQUET_BLOOM_FILTER_NDV_COLUMN_PREFIX}trace_id"),
+                "1000000".to_string(),
+            ),
+        ]);
+        let props = apply_bloom_filter_properties(WriterProperties::builder(), &properties).build();
+
+        assert_eq!(
+            props.bloom_filter_properties(&ColumnPath::from("trace_id")),
+            Some(&parquet::file::properties::BloomFilterProperties {
+                fpp: parquet::file::properties::DEFAULT_BLOOM_FILTER_FPP,
+                ndv: 1_000_000,
+            })
+        );
+    }
+
+    /// A zero or unparsable ndv can't size a filter; it must be ignored
+    /// rather than produce a nonsensical one.
+    #[test]
+    fn an_invalid_ndv_is_ignored() {
+        for value in ["0", "-5", "many"] {
+            let properties: HashMap<String, String> = HashMap::from([
+                (
+                    format!("{WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX}trace_id"),
+                    "true".to_string(),
+                ),
+                (
+                    format!("{WRITE_PARQUET_BLOOM_FILTER_NDV_COLUMN_PREFIX}trace_id"),
+                    value.to_string(),
+                ),
+            ]);
+            let props =
+                apply_bloom_filter_properties(WriterProperties::builder(), &properties).build();
+
+            let ndv = props
+                .bloom_filter_properties(&ColumnPath::from("trace_id"))
+                .map(|properties| properties.ndv);
+            assert_eq!(
+                ndv,
+                Some(parquet::file::properties::DEFAULT_BLOOM_FILTER_NDV),
+                "ndv {value:?} should have been ignored"
+            );
+        }
     }
 
     /// An fpp outside `(0, 1)` cannot size a filter; it must be ignored rather


### PR DESCRIPTION
The Parquet writer ignored the table properties that describe how to write Parquet.

Compression was hardcoded to zstd level 1 — while `CreateTableBuilder` records `write.parquet.compression-codec = zstd` and `write.parquet.compression-level = 3` on every new table, so the metadata described a file that was never written. Page, page-row and dictionary sizing were not reachable at all. And a bloom filter could only be turned on, never sized: it took the default false-positive rate whatever the column's cardinality, so a high-cardinality column got either wasted reads or a needlessly large footer.

Now honored:

| Property | Maps to |
|---|---|
| `write.parquet.compression-codec` | `set_compression` (uncompressed/snappy/gzip/lz4/lz4_raw/brotli/zstd) |
| `write.parquet.compression-level` | the codec's level, where it takes one |
| `write.parquet.page-size-bytes` | `set_data_page_size_limit` |
| `write.parquet.page-row-limit` | `set_data_page_row_count_limit` |
| `write.parquet.dict-size-bytes` | `set_dictionary_page_size_limit` |
| `write.parquet.bloom-filter-fpp.column.<name>` | `set_column_bloom_filter_fpp` |

An unknown codec, unparsable number, a level a codec rejects, or an fpp outside `(0, 1)` is ignored rather than failing the write — a bad property degrades to the default. A level on a codec that takes none is ignored, matching the Java implementation.

**Deliberately not covered:** `write.parquet.row-group-size-bytes` has no parquet-rs equivalent (`set_max_row_group_size` counts rows, not bytes), so honoring it needs byte accounting in the write loop. `write.parquet.bloom-filter-max-bytes` has no equivalent either — parquet-rs sizes a filter from ndv and fpp.

Tests: 6 covering each property, the ignore-and-default paths, and the levelless-codec case.