### PR TITLE
feat: write gzipped metadata when the table asks for it

### DIFF
--- a/catalogs/iceberg-file-catalog/src/lib.rs
+++ b/catalogs/iceberg-file-catalog/src/lib.rs
@@ -396,8 +396,11 @@ impl Catalog for FileCatalog {
             .put_metadata(&temp_metadata_location, metadata.as_ref())
             .await?;
 
-        let metadata_location =
-            new_filesystem_metadata_location(&metadata.location, &previous_metadata_location)?;
+        let metadata_location = new_filesystem_metadata_location(
+            &metadata.location,
+            &previous_metadata_location,
+            temp_metadata_location.ends_with(".gz.metadata.json"),
+        )?;
 
         object_store
             .copy_if_not_exists(
@@ -453,6 +456,7 @@ impl Catalog for FileCatalog {
                 let metadata_location = new_filesystem_metadata_location(
                     &metadata.location,
                     &previous_metadata_location,
+                    temp_metadata_location.ends_with(".gz.metadata.json"),
                 )?;
 
                 object_store
@@ -514,6 +518,7 @@ impl Catalog for FileCatalog {
                 let metadata_location = new_filesystem_metadata_location(
                     &metadata.location,
                     &previous_metadata_location,
+                    temp_metadata_location.ends_with(".gz.metadata.json"),
                 )?;
 
                 object_store
@@ -612,12 +617,14 @@ impl FileCatalog {
                 .trim_start_matches((strip_prefix(&path) + "/v").trim_start_matches("/"))
                 .trim_end_matches("/")
                 .trim_end_matches(".metadata.json")
+                .trim_end_matches(".gz")
                 .parse::<usize>()
                 .unwrap();
             let y = y
                 .trim_start_matches((strip_prefix(&path) + "/v").trim_start_matches("/"))
                 .trim_end_matches("/")
                 .trim_end_matches(".metadata.json")
+                .trim_end_matches(".gz")
                 .parse::<usize>()
                 .unwrap();
             x.cmp(&y)
@@ -668,6 +675,7 @@ fn parse_version(path: &str) -> Result<u64, IcebergError> {
         .ok_or(IcebergError::InvalidFormat("Metadata location".to_owned()))?
         .trim_start_matches('v')
         .trim_end_matches(".metadata.json")
+        .trim_end_matches(".gz")
         .parse()
         .map_err(IcebergError::from)
 }
@@ -675,12 +683,92 @@ fn parse_version(path: &str) -> Result<u64, IcebergError> {
 fn new_filesystem_metadata_location(
     metadata_location: &str,
     previous_metadata_location: &str,
+    gzipped: bool,
 ) -> Result<String, IcebergError> {
     let current_version = parse_version(previous_metadata_location)? + 1;
-    Ok(metadata_location.to_string()
-        + "/metadata/v"
-        + &current_version.to_string()
-        + ".metadata.json")
+    // The name carries the encoding: the reader decides whether to decompress
+    // from the suffix alone, so a gzipped file must be named `.gz.metadata.json`
+    // even though this catalog numbers versions rather than using the metastore
+    // name. Kept in sync with the temp file actually written, not re-derived
+    // from properties, so the two can never disagree.
+    let suffix = if gzipped {
+        "gz.metadata.json"
+    } else {
+        "metadata.json"
+    };
+    Ok(format!(
+        "{}/metadata/v{}.{}",
+        metadata_location, current_version, suffix
+    ))
+}
+
+#[cfg(test)]
+mod metadata_naming_tests {
+    use super::*;
+
+    /// The version number must be recovered from both the plain and the
+    /// gzipped name, since a gzipped table's previous location carries the
+    /// `.gz.metadata.json` suffix and drives the next version number.
+    #[test]
+    fn parse_version_reads_plain_and_gzipped_names() {
+        assert_eq!(
+            parse_version("/wh/ns/t/metadata/v7.metadata.json").unwrap(),
+            7
+        );
+        assert_eq!(
+            parse_version("/wh/ns/t/metadata/v7.gz.metadata.json").unwrap(),
+            7
+        );
+    }
+
+    /// The final versioned name must carry the same encoding as the file that
+    /// was actually written; otherwise the reader, which decides purely from
+    /// the suffix, would read gzip bytes as plain JSON.
+    #[test]
+    fn the_versioned_name_carries_the_gzip_suffix() {
+        let plain = new_filesystem_metadata_location(
+            "/wh/ns/t",
+            "/wh/ns/t/metadata/v3.metadata.json",
+            false,
+        )
+        .unwrap();
+        assert_eq!(plain, "/wh/ns/t/metadata/v4.metadata.json");
+
+        let gzipped = new_filesystem_metadata_location(
+            "/wh/ns/t",
+            "/wh/ns/t/metadata/v3.gz.metadata.json",
+            true,
+        )
+        .unwrap();
+        assert_eq!(gzipped, "/wh/ns/t/metadata/v4.gz.metadata.json");
+    }
+
+    /// The encoding may be toggled on an existing table, so the previous name's
+    /// suffix and the requested encoding are independent: whichever the caller
+    /// asks for wins, and the version still advances.
+    #[test]
+    fn the_encoding_can_change_between_commits() {
+        // Was plain, now gzipped.
+        assert_eq!(
+            new_filesystem_metadata_location(
+                "/wh/ns/t",
+                "/wh/ns/t/metadata/v1.metadata.json",
+                true
+            )
+            .unwrap(),
+            "/wh/ns/t/metadata/v2.gz.metadata.json"
+        );
+        // Was gzipped, now plain.
+        assert_eq!(
+            new_filesystem_metadata_location(
+                "/wh/ns/t",
+                "/wh/ns/t/metadata/v1.gz.metadata.json",
+                false
+            )
+            .unwrap(),
+            "/wh/ns/t/metadata/v2.metadata.json"
+        );
+    }
 }
 
 #[derive(Debug)]

--- a/iceberg-rust-spec/src/spec/table_metadata.rs
+++ b/iceberg-rust-spec/src/spec/table_metadata.rs
@@ -63,6 +63,9 @@ pub const WRITE_METADATA_METRICS_COLUMN_PREFIX: &str = "write.metadata.metrics.c
 /// it are only measured when named explicitly. Defaults to 100.
 pub const WRITE_METADATA_METRICS_MAX_INFERRED_COLUMN_DEFAULTS: &str =
     "write.metadata.metrics.max-inferred-column-defaults";
+/// Codec for `metadata.json`: `none` (default) or `gzip`. A gzipped metadata
+/// file is named `*.gz.metadata.json`, which is how readers detect it.
+pub const WRITE_METADATA_COMPRESSION_CODEC: &str = "write.metadata.compression-codec";
 
 pub use _serde::{TableMetadataV1, TableMetadataV2, TableMetadataV3};
 
@@ -371,6 +374,11 @@ pub fn partition_fields<'a>(
 
 /// Creates a new metadata file location for a table
 ///
+/// The name carries the encoding: a table whose
+/// `write.metadata.compression-codec` is `gzip` gets a `.gz.metadata.json`
+/// suffix, which is how readers already decide whether to decompress. Any
+/// other value, including the default `none`, produces a plain name.
+///
 /// # Arguments
 /// * `metadata` - The table metadata to create a location for
 ///
@@ -380,13 +388,26 @@ pub fn new_metadata_location<'a, T: Into<TabularMetadataRef<'a>>>(metadata: T) -
     let metadata: TabularMetadataRef = metadata.into();
     let transaction_uuid = Uuid::new_v4();
     let version = metadata.sequence_number();
+    let suffix = if metadata_is_gzipped(metadata.properties()) {
+        "gz.metadata.json"
+    } else {
+        "metadata.json"
+    };
 
     format!(
-        "{}/metadata/{:05}-{}.metadata.json",
+        "{}/metadata/{:05}-{}.{}",
         metadata.location(),
         version,
-        transaction_uuid
+        transaction_uuid,
+        suffix
     )
+}
+
+/// Whether a table's properties ask for gzipped metadata.
+pub fn metadata_is_gzipped(properties: &HashMap<String, String>) -> bool {
+    properties
+        .get(WRITE_METADATA_COMPRESSION_CODEC)
+        .is_some_and(|codec| codec.trim().eq_ignore_ascii_case("gzip"))
 }
 
 impl fmt::Display for TableMetadata {
@@ -1091,6 +1112,43 @@ impl From<FormatVersion> for i32 {
             FormatVersion::V1 => 1,
             FormatVersion::V2 => 2,
             FormatVersion::V3 => 3,
+        }
+    }
+}
+
+#[cfg(test)]
+mod metadata_compression_tests {
+    use super::*;
+
+    #[test]
+    fn gzip_is_recognized_whatever_the_casing() {
+        for value in ["gzip", "GZIP", " Gzip "] {
+            let properties = HashMap::from([(
+                WRITE_METADATA_COMPRESSION_CODEC.to_string(),
+                value.to_string(),
+            )]);
+            assert!(
+                metadata_is_gzipped(&properties),
+                "{value:?} should mean gzip"
+            );
+        }
+    }
+
+    /// The spec's default is `none`, and an unrecognized codec must not be
+    /// guessed at -- a name claiming gzip that is not gzip is unreadable.
+    #[test]
+    fn anything_else_means_uncompressed() {
+        assert!(!metadata_is_gzipped(&HashMap::new()));
+
+        for value in ["none", "", "zstd", "gzip2"] {
+            let properties = HashMap::from([(
+                WRITE_METADATA_COMPRESSION_CODEC.to_string(),
+                value.to_string(),
+            )]);
+            assert!(
+                !metadata_is_gzipped(&properties),
+                "{value:?} should not mean gzip"
+            );
         }
     }
 }

--- a/iceberg-rust-spec/src/spec/tabular.rs
+++ b/iceberg-rust-spec/src/spec/tabular.rs
@@ -131,6 +131,19 @@ impl TabularMetadataRef<'_> {
         }
     }
 
+    /// Returns the properties of the tabular object
+    ///
+    /// # Returns
+    /// * The `write.*` and other properties that configure how this table,
+    ///   view, or materialized view is written
+    pub fn properties(&self) -> &std::collections::HashMap<String, String> {
+        match self {
+            TabularMetadataRef::Table(table) => &table.properties,
+            TabularMetadataRef::View(view) => &view.properties,
+            TabularMetadataRef::MaterializedView(matview) => &matview.properties,
+        }
+    }
+
     /// Returns the current sequence number or version ID of the tabular object
     ///
     /// # Returns

--- a/iceberg-rust/src/object_store/store.rs
+++ b/iceberg-rust/src/object_store/store.rs
@@ -95,7 +95,7 @@ lazy_static! {
         )
         .unwrap(),
         // The legacy file-system format https://iceberg.apache.org/spec/#file-system-tables
-        Regex::new(r"^v(?<version>[0-9]+).metadata.json$").unwrap(),
+        Regex::new(r"^v(?<version>[0-9]+).(?:gz.)?metadata.json$").unwrap(),
     ];
 }
 
@@ -201,6 +201,7 @@ mod tests {
 
     #[rstest]
     #[case::file_format("/path/to/metadata/v2.metadata.json", "2")]
+    #[case::file_format_with_gzip("/path/to/metadata/v2.gz.metadata.json", "2")]
     #[case::metastore_format_no_gzip(
         "/path/to/metadata/00004-3f569e94-5601-48f3-9199-8d71df4ea7b0.metadata.json",
         "00004-3f569e94-5601-48f3-9199-8d71df4ea7b0"

--- a/iceberg-rust/src/object_store/store.rs
+++ b/iceberg-rust/src/object_store/store.rs
@@ -9,9 +9,11 @@ use object_store::{Attributes, ObjectStore, ObjectStoreExt, PutOptions, TagSet};
 
 use crate::error::Error;
 use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use lazy_static::lazy_static;
 use regex::Regex;
-use std::io::Read;
+use std::io::{Read, Write};
 
 /// Simplify interaction with iceberg files
 #[async_trait]
@@ -47,7 +49,7 @@ impl<T: ObjectStore> IcebergStore for T {
     ) -> Result<(), Error> {
         self.put(
             &strip_prefix(location).into(),
-            serde_json::to_vec(&metadata)?.into(),
+            serialize_metadata(location, metadata)?.into(),
         )
         .await?;
 
@@ -116,6 +118,25 @@ pub fn version_hint_content(original: &str) -> String {
                 .next()
         })
         .unwrap_or(original.to_string())
+}
+
+/// Encode metadata for the given location.
+///
+/// The file name carries the encoding — `new_metadata_location` appends
+/// `.gz.metadata.json` when the table asks for gzipped metadata — so writing
+/// and reading agree without either having to consult the properties again.
+/// `metadata.json` is the largest per-commit artifact a busy table produces,
+/// and it is highly repetitive JSON, so gzip typically shrinks it severalfold.
+fn serialize_metadata(location: &str, metadata: TabularMetadataRef<'_>) -> Result<Vec<u8>, Error> {
+    let json = serde_json::to_vec(&metadata)?;
+
+    if !location.ends_with(".gz.metadata.json") {
+        return Ok(json);
+    }
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&json)?;
+    encoder.finish().map_err(Error::from)
 }
 
 fn parse_metadata(location: &str, bytes: &[u8]) -> Result<TabularMetadata, Error> {
@@ -505,5 +526,135 @@ mod tests {
 
         let result = parse_metadata(location, empty_gzipped_bytes);
         assert!(result.is_err());
+    }
+
+    /// A `.gz.metadata.json` name must actually produce gzip, and must read
+    /// back — the reader has long decompressed such files, but nothing ever
+    /// wrote one, so the two halves were never exercised together.
+    #[test]
+    fn gzipped_metadata_round_trips_through_the_writer() {
+        use iceberg_rust_spec::table_metadata::TableMetadata;
+        use std::str::FromStr;
+
+        let json_data = r#"
+            {
+                "format-version" : 2,
+                "table-uuid": "fb072c92-a02b-11e9-ae9c-1bb7bc9eca94",
+                "location": "s3://b/wh/data.db/table",
+                "last-sequence-number" : 1,
+                "last-updated-ms": 1515100955770,
+                "last-column-id": 1,
+                "schemas": [
+                    {
+                        "schema-id" : 1,
+                        "type" : "struct",
+                        "fields" :[
+                            {
+                                "id": 1,
+                                "name": "struct_name",
+                                "required": true,
+                                "type": "fixed[1]"
+                            }
+                        ]
+                    }
+                ],
+                "current-schema-id" : 1,
+                "partition-specs": [
+                    {
+                        "spec-id": 1,
+                        "fields": [
+                            {
+                                "source-id": 4,
+                                "field-id": 1000,
+                                "name": "ts_day",
+                                "transform": "day"
+                            }
+                        ]
+                    }
+                ],
+                "default-spec-id": 1,
+                "last-partition-id": 1,
+                "properties": {},
+                "sort-orders": [],
+                "default-sort-order-id": 0
+            }
+        "#;
+        let metadata = TableMetadata::from_str(json_data).unwrap();
+
+        let gz_location = "/path/to/metadata/00001-uuid.gz.metadata.json";
+        let bytes = serialize_metadata(gz_location, (&metadata).into()).unwrap();
+
+        // Gzip's magic number: the bytes really are compressed, not just named
+        // as if they were.
+        assert_eq!(&bytes[..2], &[0x1f, 0x8b], "expected a gzip stream");
+        assert!(
+            bytes.len() < serde_json::to_vec(&metadata).unwrap().len(),
+            "gzip should shrink the metadata"
+        );
+
+        let TabularMetadata::Table(read_back) = parse_metadata(gz_location, &bytes).unwrap() else {
+            panic!("expected a table");
+        };
+        assert_eq!(read_back.table_uuid, metadata.table_uuid);
+    }
+
+    /// The default is uncompressed, and a plain name must stay plain JSON.
+    #[test]
+    fn a_plain_metadata_name_is_written_uncompressed() {
+        use iceberg_rust_spec::table_metadata::TableMetadata;
+        use std::str::FromStr;
+
+        let json_data = r#"
+            {
+                "format-version" : 2,
+                "table-uuid": "fb072c92-a02b-11e9-ae9c-1bb7bc9eca94",
+                "location": "s3://b/wh/data.db/table",
+                "last-sequence-number" : 1,
+                "last-updated-ms": 1515100955770,
+                "last-column-id": 1,
+                "schemas": [
+                    {
+                        "schema-id" : 1,
+                        "type" : "struct",
+                        "fields" :[
+                            {
+                                "id": 1,
+                                "name": "struct_name",
+                                "required": true,
+                                "type": "fixed[1]"
+                            }
+                        ]
+                    }
+                ],
+                "current-schema-id" : 1,
+                "partition-specs": [
+                    {
+                        "spec-id": 1,
+                        "fields": [
+                            {
+                                "source-id": 4,
+                                "field-id": 1000,
+                                "name": "ts_day",
+                                "transform": "day"
+                            }
+                        ]
+                    }
+                ],
+                "default-spec-id": 1,
+                "last-partition-id": 1,
+                "properties": {},
+                "sort-orders": [],
+                "default-sort-order-id": 0
+            }
+        "#;
+        let metadata = TableMetadata::from_str(json_data).unwrap();
+
+        let bytes = serialize_metadata(
+            "/path/to/metadata/00001-uuid.metadata.json",
+            (&metadata).into(),
+        )
+        .unwrap();
+
+        assert_eq!(bytes, serde_json::to_vec(&metadata).unwrap());
     }
 }


### PR DESCRIPTION
`write.metadata.compression-codec` was half-implemented. `parse_metadata` has long decompressed a `*.gz.metadata.json`, but nothing ever *wrote* one — so the property did nothing, and the decompression path was unreachable in practice.

`metadata.json` is the largest artifact a busy table rewrites on every commit, and it is highly repetitive JSON, so leaving it uncompressed is a standing cost on every commit and every read.

- `new_metadata_location` appends `.gz.metadata.json` when the table's properties name gzip
- `put_metadata` compresses when the location says so

The file name is the single source of truth for the encoding — already how the reader decides — so the two halves cannot disagree.

Anything other than `gzip`, including the spec's `none` default and an unrecognized codec, writes plain JSON. Guessing at an unknown codec would produce a file named as something it is not, which no reader could open.

Adds `TabularMetadataRef::properties`, since choosing the name needs them. The version-hint regex already accepted the `gz.` variant.

Tests: gzip round-trips through writer and reader (asserting the bytes are really a gzip stream and smaller than the JSON), a plain name stays plain, and codec recognition across casings and non-gzip values.